### PR TITLE
Add overlay navigation and zoom controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+uploads/

--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -72,6 +72,11 @@ def sha256(path: str) -> str:
 def safe_album(name: str) -> str:
     return "".join(c for c in name if c.isalnum() or c == "_")
 
+def valid_album(name: str) -> bool:
+    """Return True if the given name is a legal album path segment."""
+    import re
+    return bool(re.fullmatch(r"[A-Za-z0-9_]+", name))
+
 def sanitize_filename(name: str) -> str:
     """Allow UTF-8 filenames while stripping path separators and control chars."""
     name = os.path.basename(name)
@@ -346,9 +351,10 @@ def rename_album(album_name):
     """Rename an album folder."""
     album = safe_album(album_name)
     data = request.get_json(force=True)
-    new = safe_album(data.get('name', ''))
-    if not new:
-        return jsonify({'ok': False}), 400
+    newname = data.get('name', '')
+    if not valid_album(newname):
+        return jsonify({'ok': False, 'msg': 'invalid'}), 400
+    new = safe_album(newname)
     src = os.path.join(UPLOAD_ROOT, album)
     dst = os.path.join(UPLOAD_ROOT, new)
     if not os.path.isdir(src):

--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -292,10 +292,20 @@ def album(album_name):
     order = request.args.get('order', 'desc')
     rev = (order == 'desc')
     items = []
+    counts = {'image': 0, 'video': 0, 'raw': 0, 'other': 0}
     for name in os.listdir(path):
         fp = os.path.join(path, name)
         if not os.path.isfile(fp):
             continue
+        ext = os.path.splitext(name)[1].lower()
+        if ext in IMAGE_EXTS:
+            counts['image'] += 1
+        elif ext in VIDEO_EXTS:
+            counts['video'] += 1
+        elif ext in RAW_EXTS:
+            counts['raw'] += 1
+        else:
+            counts['other'] += 1
         items.append({
             'name': name,
             'size': os.path.getsize(fp),
@@ -313,7 +323,7 @@ def album(album_name):
         sort = 'mtime'
     if order not in {'asc','desc'}:
         order = 'desc'
-    return render_template('album.html', album=album, files=items, sort=sort, order=order)
+    return render_template('album.html', album=album, files=items, sort=sort, order=order, counts=counts)
 
 @app.route("/<album_name>/download_all")
 def download_all(album_name):
@@ -329,6 +339,24 @@ def download_all(album_name):
         except Exception:
             pass
     return resp
+
+
+@app.route("/<album_name>/rename", methods=['POST'])
+def rename_album(album_name):
+    """Rename an album folder."""
+    album = safe_album(album_name)
+    data = request.get_json(force=True)
+    new = safe_album(data.get('name', ''))
+    if not new:
+        return jsonify({'ok': False}), 400
+    src = os.path.join(UPLOAD_ROOT, album)
+    dst = os.path.join(UPLOAD_ROOT, new)
+    if not os.path.isdir(src):
+        abort(404)
+    if os.path.isdir(dst):
+        return jsonify({'ok': False, 'msg': 'exists'}), 400
+    os.rename(src, dst)
+    return jsonify({'ok': True, 'new': new})
 
 if __name__=='__main__':
     print('运行: http://127.0.0.1:5000')

--- a/templates/album.html
+++ b/templates/album.html
@@ -25,6 +25,7 @@
     figcaption .meta{font-size:.75rem;color:#666;display:block;line-height:1.2;}
     #overlay{position:fixed;inset:0;display:none;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:999;}
     #overlay img,#overlay video{max-width:90vw;max-height:90vh;border-radius:6px;transition:transform .2s;}
+    #overlay img.dragging{transition:none;}
     #overlay .nav{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);border:none;color:#fff;font-size:2rem;padding:.5rem;border-radius:50%;cursor:pointer;user-select:none;}
     #overlay #prev{left:1rem;}
     #overlay #next{right:1rem;}
@@ -134,11 +135,29 @@ document.addEventListener('keydown',e=>{const o=document.getElementById('overlay
 const overlay=document.getElementById('overlay');
 const imgEl=document.querySelector('#overlay img');
 let dragging=false,lastX=0,lastY=0;
-imgEl.addEventListener('mousedown',e=>{if(e.button!==0)return;dragging=true;lastX=e.clientX;lastY=e.clientY;e.preventDefault();e.stopPropagation();});
+imgEl.addEventListener('mousedown',e=>{
+  if(e.button!==0)return;
+  dragging=true;
+  imgEl.classList.add('dragging');
+  lastX=e.clientX;
+  lastY=e.clientY;
+  e.preventDefault();
+  e.stopPropagation();
+});
 imgEl.addEventListener('click',e=>e.stopPropagation());
 overlay.addEventListener('click',e=>{if(e.target===overlay)hide();});
-document.addEventListener('mousemove',e=>{if(!dragging)return;offX+=e.clientX-lastX;offY+=e.clientY-lastY;lastX=e.clientX;lastY=e.clientY;updateTransform();});
-document.addEventListener('mouseup',()=>{dragging=false;});
+document.addEventListener('mousemove',e=>{
+  if(!dragging)return;
+  offX+=e.clientX-lastX;
+  offY+=e.clientY-lastY;
+  lastX=e.clientX;
+  lastY=e.clientY;
+  updateTransform();
+});
+document.addEventListener('mouseup',()=>{
+  dragging=false;
+  imgEl.classList.remove('dragging');
+});
 overlay.addEventListener('wheel',e=>{if(imgEl.style.display==='none')return;e.preventDefault();const rect=imgEl.getBoundingClientRect();const cx=e.clientX-(rect.left+rect.width/2);const cy=e.clientY-(rect.top+rect.height/2);const old=scale;scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);const ratio=scale/old;offX-=cx*(ratio-1);offY-=cy*(ratio-1);updateTransform();},{passive:false});
 </script>
 </body>

--- a/templates/album.html
+++ b/templates/album.html
@@ -32,7 +32,10 @@
   </style>
 </head>
 <body>
-<h2>{{ album }}</h2>
+<h2>{{ album }} <button class='btn' onclick='renameAlbum()'>重命名</button></h2>
+<p style='font-size:.9rem;color:#555;'>
+  图片 {{ counts.image }} ，视频 {{ counts.video }} ，RAW {{ counts.raw }} ，其他 {{ counts.other }}
+</p>
 <div style='text-align:right;margin-bottom:.5rem;'>
   排序:
   <select id='sortsel' onchange="updateSort()">
@@ -119,6 +122,15 @@ async function upload(){const fs=[...(dropped||input.files)];if(!fs.length)retur
 function delFile(name){if(!confirm('删除 '+name+' ?'))return;fetch(location.pathname+'/delete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file:name})}).then(()=>location.reload());}
 function delAll(){if(!confirm('确定清空相册?'))return;fetch(location.pathname+'/delete_all',{method:'POST'}).then(()=>location.reload());}
 function pack(){const es=new EventSource(location.pathname+'/pack');pw.style.display='block';pb.style.width='0';pt.textContent='';es.onmessage=e=>{if(e.data==='done'){es.close();location.href=location.pathname+'/download_all';}else{pb.style.width=(parseFloat(e.data)*100).toFixed(1)+'%';pt.textContent='打包 '+(parseFloat(e.data)*100).toFixed(0)+'%';}};}
+function renameAlbum(){
+  const name=prompt('新相册名', '{{ album }}');
+  if(!name)return;
+  fetch(location.pathname+'/rename',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({name})
+  }).then(r=>r.json()).then(d=>{if(d.ok){location.href='/'+encodeURIComponent(d.new);}else{alert('重命名失败');}});
+}
 const items=[...document.querySelectorAll('.grid img, .grid video')];
 let idx=-1,scale=1,offX=0,offY=0;
 function updateTransform(){

--- a/templates/album.html
+++ b/templates/album.html
@@ -125,6 +125,7 @@ function pack(){const es=new EventSource(location.pathname+'/pack');pw.style.dis
 function renameAlbum(){
   const name=prompt('新相册名', '{{ album }}');
   if(!name)return;
+  if(!/^[A-Za-z0-9_]+$/.test(name)){alert('名称含非法字符');return;}
   fetch(location.pathname+'/rename',{
     method:'POST',
     headers:{'Content-Type':'application/json'},

--- a/templates/album.html
+++ b/templates/album.html
@@ -83,7 +83,7 @@
   </div>
 </figure>{% endfor %}
 </div>
-<div id='overlay' onclick='hide()'>
+<div id='overlay'>
   <button id='prev' class='nav' onclick='event.stopPropagation();prev()'>&lsaquo;</button>
   <img>
   <video controls style='display:none'></video>
@@ -135,6 +135,8 @@ const overlay=document.getElementById('overlay');
 const imgEl=document.querySelector('#overlay img');
 let dragging=false,lastX=0,lastY=0;
 imgEl.addEventListener('mousedown',e=>{if(e.button!==0)return;dragging=true;lastX=e.clientX;lastY=e.clientY;e.preventDefault();e.stopPropagation();});
+imgEl.addEventListener('click',e=>e.stopPropagation());
+overlay.addEventListener('click',e=>{if(e.target===overlay)hide();});
 document.addEventListener('mousemove',e=>{if(!dragging)return;offX+=e.clientX-lastX;offY+=e.clientY-lastY;lastX=e.clientX;lastY=e.clientY;updateTransform();});
 document.addEventListener('mouseup',()=>{dragging=false;});
 overlay.addEventListener('wheel',e=>{if(imgEl.style.display==='none')return;e.preventDefault();const rect=imgEl.getBoundingClientRect();const cx=e.clientX-(rect.left+rect.width/2);const cy=e.clientY-(rect.top+rect.height/2);const old=scale;scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);const ratio=scale/old;offX-=cx*(ratio-1);offY-=cy*(ratio-1);updateTransform();},{passive:false});

--- a/templates/album.html
+++ b/templates/album.html
@@ -24,7 +24,10 @@
     figcaption .name{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;word-break:break-all;min-height:2.4em;}
     figcaption .meta{font-size:.75rem;color:#666;display:block;line-height:1.2;}
     #overlay{position:fixed;inset:0;display:none;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:999;}
-    #overlay img,#overlay video{max-width:90vw;max-height:90vh;border-radius:6px;}
+    #overlay img,#overlay video{max-width:90vw;max-height:90vh;border-radius:6px;transition:transform .2s;}
+    #overlay .nav{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);border:none;color:#fff;font-size:2rem;padding:.5rem;border-radius:50%;cursor:pointer;user-select:none;}
+    #overlay #prev{left:1rem;}
+    #overlay #next{right:1rem;}
   </style>
 </head>
 <body>
@@ -81,8 +84,10 @@
 </figure>{% endfor %}
 </div>
 <div id='overlay' onclick='hide()'>
+  <button id='prev' class='nav' onclick='event.stopPropagation();prev()'>&lsaquo;</button>
   <img>
   <video controls style='display:none'></video>
+  <button id='next' class='nav' onclick='event.stopPropagation();next()'>&rsaquo;</button>
 </div>
 <script>
 const pw=document.getElementById('progwrap'),pb=document.getElementById('progbar'),pt=document.getElementById('progtext');
@@ -113,9 +118,16 @@ async function upload(){const fs=[...(dropped||input.files)];if(!fs.length)retur
 function delFile(name){if(!confirm('删除 '+name+' ?'))return;fetch(location.pathname+'/delete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file:name})}).then(()=>location.reload());}
 function delAll(){if(!confirm('确定清空相册?'))return;fetch(location.pathname+'/delete_all',{method:'POST'}).then(()=>location.reload());}
 function pack(){const es=new EventSource(location.pathname+'/pack');pw.style.display='block';pb.style.width='0';pt.textContent='';es.onmessage=e=>{if(e.data==='done'){es.close();location.href=location.pathname+'/download_all';}else{pb.style.width=(parseFloat(e.data)*100).toFixed(1)+'%';pt.textContent='打包 '+(parseFloat(e.data)*100).toFixed(0)+'%';}};}
-function showImage(el){const o=document.getElementById('overlay');const img=o.querySelector('img');const v=o.querySelector('video');v.pause();v.style.display='none';v.src='';img.style.display='block';img.src=el.dataset.full;o.style.display='flex';}
-function showVideo(el){const o=document.getElementById('overlay');const img=o.querySelector('img');const v=o.querySelector('video');img.style.display='none';img.src='';v.style.display='block';v.src=el.dataset.full;o.style.display='flex';v.play();}
-function hide(){const o=document.getElementById('overlay');o.style.display='none';const v=o.querySelector('video');v.pause();v.src='';}
+const items=[...document.querySelectorAll('.grid img, .grid video')];
+let idx=-1,scale=1;
+function showAt(i){if(i<0||i>=items.length)return;idx=i;scale=1;const it=items[i];const o=document.getElementById('overlay');const img=o.querySelector('img');const v=o.querySelector('video');if(it.tagName.toLowerCase()==='video'){img.style.display='none';img.src='';v.style.display='block';v.src=it.dataset.full;o.style.display='flex';v.play();}else{v.pause();v.style.display='none';v.src='';img.style.display='block';img.style.transform='scale(1)';img.src=it.dataset.full;o.style.display='flex';}}
+function showImage(el){showAt(items.indexOf(el));}
+function showVideo(el){showAt(items.indexOf(el));}
+function hide(){const o=document.getElementById('overlay');o.style.display='none';const v=o.querySelector('video');v.pause();v.src='';idx=-1;}
+function next(){if(idx<items.length-1)showAt(idx+1);}
+function prev(){if(idx>0)showAt(idx-1);}
+document.addEventListener('keydown',e=>{const o=document.getElementById('overlay');if(o.style.display!=='flex')return;if(e.key==='ArrowRight'){next();e.preventDefault();}else if(e.key==='ArrowLeft'){prev();e.preventDefault();}});
+document.getElementById('overlay').addEventListener('wheel',e=>{const img=document.querySelector('#overlay img');if(img.style.display==='none')return;e.preventDefault();scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);img.style.transform=`scale(${scale})`;},{passive:false});
 </script>
 </body>
 </html>

--- a/templates/album.html
+++ b/templates/album.html
@@ -119,15 +119,25 @@ function delFile(name){if(!confirm('删除 '+name+' ?'))return;fetch(location.pa
 function delAll(){if(!confirm('确定清空相册?'))return;fetch(location.pathname+'/delete_all',{method:'POST'}).then(()=>location.reload());}
 function pack(){const es=new EventSource(location.pathname+'/pack');pw.style.display='block';pb.style.width='0';pt.textContent='';es.onmessage=e=>{if(e.data==='done'){es.close();location.href=location.pathname+'/download_all';}else{pb.style.width=(parseFloat(e.data)*100).toFixed(1)+'%';pt.textContent='打包 '+(parseFloat(e.data)*100).toFixed(0)+'%';}};}
 const items=[...document.querySelectorAll('.grid img, .grid video')];
-let idx=-1,scale=1;
-function showAt(i){if(i<0||i>=items.length)return;idx=i;scale=1;const it=items[i];const o=document.getElementById('overlay');const img=o.querySelector('img');const v=o.querySelector('video');if(it.tagName.toLowerCase()==='video'){img.style.display='none';img.src='';v.style.display='block';v.src=it.dataset.full;o.style.display='flex';v.play();}else{v.pause();v.style.display='none';v.src='';img.style.display='block';img.style.transform='scale(1)';img.src=it.dataset.full;o.style.display='flex';}}
+let idx=-1,scale=1,offX=0,offY=0;
+function updateTransform(){
+  const img=document.querySelector('#overlay img');
+  img.style.transform=`translate(${offX}px,${offY}px) scale(${scale})`;
+}
+function showAt(i){if(i<0||i>=items.length)return;idx=i;scale=1;offX=0;offY=0;const it=items[i];const o=document.getElementById('overlay');const img=o.querySelector('img');const v=o.querySelector('video');if(it.tagName.toLowerCase()==='video'){img.style.display='none';img.src='';v.style.display='block';v.src=it.dataset.full;o.style.display='flex';v.play();}else{v.pause();v.style.display='none';v.src='';img.style.display='block';img.src=it.dataset.full;o.style.display='flex';updateTransform();}}
 function showImage(el){showAt(items.indexOf(el));}
 function showVideo(el){showAt(items.indexOf(el));}
 function hide(){const o=document.getElementById('overlay');o.style.display='none';const v=o.querySelector('video');v.pause();v.src='';idx=-1;}
 function next(){if(idx<items.length-1)showAt(idx+1);}
 function prev(){if(idx>0)showAt(idx-1);}
 document.addEventListener('keydown',e=>{const o=document.getElementById('overlay');if(o.style.display!=='flex')return;if(e.key==='ArrowRight'){next();e.preventDefault();}else if(e.key==='ArrowLeft'){prev();e.preventDefault();}});
-document.getElementById('overlay').addEventListener('wheel',e=>{const img=document.querySelector('#overlay img');if(img.style.display==='none')return;e.preventDefault();scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);img.style.transform=`scale(${scale})`;},{passive:false});
+const overlay=document.getElementById('overlay');
+const imgEl=document.querySelector('#overlay img');
+let dragging=false,lastX=0,lastY=0;
+imgEl.addEventListener('mousedown',e=>{if(e.button!==0)return;dragging=true;lastX=e.clientX;lastY=e.clientY;e.preventDefault();e.stopPropagation();});
+document.addEventListener('mousemove',e=>{if(!dragging)return;offX+=e.clientX-lastX;offY+=e.clientY-lastY;lastX=e.clientX;lastY=e.clientY;updateTransform();});
+document.addEventListener('mouseup',()=>{dragging=false;});
+overlay.addEventListener('wheel',e=>{if(imgEl.style.display==='none')return;e.preventDefault();const rect=imgEl.getBoundingClientRect();const cx=e.clientX-(rect.left+rect.width/2);const cy=e.clientY-(rect.top+rect.height/2);const old=scale;scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);const ratio=scale/old;offX-=cx*(ratio-1);offY-=cy*(ratio-1);updateTransform();},{passive:false});
 </script>
 </body>
 </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -59,3 +59,13 @@ def test_pack_zip(client, album_path):
     assert resp.status_code == 200
     assert os.path.isfile(zpath)
 
+
+def test_rename_album(client, album_path):
+    data = {"file": (io.BytesIO(b"x"), "a.jpg")}
+    client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    resp = client.post(f"/{ALBUM}/rename", json={"name": "renamed"})
+    assert resp.status_code == 200
+    assert os.path.isdir(os.path.join(UPLOAD_ROOT, "renamed"))
+    # cleanup renamed path
+    shutil.rmtree(os.path.join(UPLOAD_ROOT, "renamed"), ignore_errors=True)
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -69,3 +69,10 @@ def test_rename_album(client, album_path):
     # cleanup renamed path
     shutil.rmtree(os.path.join(UPLOAD_ROOT, "renamed"), ignore_errors=True)
 
+
+def test_rename_invalid(client, album_path):
+    data = {"file": (io.BytesIO(b"x"), "a.jpg")}
+    client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    resp = client.post(f"/{ALBUM}/rename", json={"name": "bad/"})
+    assert resp.status_code == 400
+


### PR DESCRIPTION
## Summary
- add previous/next navigation buttons to overlay
- support keyboard navigation and wheel zoom while viewing images

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_687f816fb7648320b757542c08f0d86b