### PR TITLE
Add file rename feature and tooltip

### DIFF
--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -346,6 +346,29 @@ def download_all(album_name):
     return resp
 
 
+@app.route("/<album_name>/rename_file", methods=['POST'])
+def rename_file(album_name):
+    """Rename a single file within an album."""
+    album = safe_album(album_name)
+    data = request.get_json(force=True)
+    old = data.get('old', '')
+    newname = sanitize_filename(data.get('new', ''))
+    if not old or not newname:
+        return jsonify({'ok': False, 'msg': 'invalid'}), 400
+    src = os.path.join(UPLOAD_ROOT, album, old)
+    dst = os.path.join(UPLOAD_ROOT, album, newname)
+    if not os.path.isfile(src):
+        abort(404)
+    if os.path.isfile(dst):
+        return jsonify({'ok': False, 'msg': 'exists'}), 400
+    os.rename(src, dst)
+    tp_old = thumb_path(album, old)
+    tp_new = thumb_path(album, newname)
+    if os.path.isfile(tp_old):
+        os.rename(tp_old, tp_new)
+    return jsonify({'ok': True, 'new': newname})
+
+
 @app.route("/<album_name>/rename", methods=['POST'])
 def rename_album(album_name):
     """Rename an album folder."""

--- a/templates/album.html
+++ b/templates/album.html
@@ -76,13 +76,14 @@
   <img src='{{ url_for("thumb", album_name=album, filename=f.name) }}' data-full='{{ url_for("static", filename=album+'/'+f.name) }}' onclick='showImage(this)'>
 {% endif %}
   <figcaption>
-    <span class='name'>{{ f.name }}</span>
+    <span class='name' title='{{ f.name }}'>{{ f.name }}</span>
     <span class='meta'>{{ f.size | fmt_bytes }}</span>
     <span class='meta'>上传: {{ f.mtime | fmt_time }}</span>
     <span class='meta'>创建: {{ f.ctime | fmt_time }}</span>
   </figcaption>
   <div>
     <a class='btn' href='{{ url_for("download_file_get", album_name=album, filename=f.name) }}'>下载</a>
+    <button class='btn' onclick="renameFile('{{ f.name }}')">重命名</button>
     <button class='btn' onclick="delFile('{{ f.name }}')">删除</button>
   </div>
 </figure>{% endfor %}
@@ -122,6 +123,15 @@ async function upload(){const fs=[...(dropped||input.files)];if(!fs.length)retur
 function delFile(name){if(!confirm('删除 '+name+' ?'))return;fetch(location.pathname+'/delete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file:name})}).then(()=>location.reload());}
 function delAll(){if(!confirm('确定清空相册?'))return;fetch(location.pathname+'/delete_all',{method:'POST'}).then(()=>location.reload());}
 function pack(){const es=new EventSource(location.pathname+'/pack');pw.style.display='block';pb.style.width='0';pt.textContent='';es.onmessage=e=>{if(e.data==='done'){es.close();location.href=location.pathname+'/download_all';}else{pb.style.width=(parseFloat(e.data)*100).toFixed(1)+'%';pt.textContent='打包 '+(parseFloat(e.data)*100).toFixed(0)+'%';}};}
+function renameFile(oldName){
+  const name=prompt('新文件名', oldName);
+  if(!name||name===oldName)return;
+  fetch(location.pathname+'/rename_file',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({old:oldName,new:name})
+  }).then(()=>location.reload());
+}
 function renameAlbum(){
   const name=prompt('新相册名', '{{ album }}');
   if(!name)return;

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -76,3 +76,11 @@ def test_rename_invalid(client, album_path):
     resp = client.post(f"/{ALBUM}/rename", json={"name": "bad/"})
     assert resp.status_code == 400
 
+
+def test_rename_file(client, album_path):
+    data = {"file": (io.BytesIO(b"x"), "old.jpg")}
+    client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    resp = client.post(f"/{ALBUM}/rename_file", json={"old": "old.jpg", "new": "new.jpg"})
+    assert resp.status_code == 200
+    assert os.path.isfile(os.path.join(album_path, "new.jpg"))
+


### PR DESCRIPTION
## Summary
- allow renaming individual files via `/rename_file`
- show full filename on hover and add per-file rename button
- test new file rename endpoint

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871b94fbd0832093edaf42f363954f