### PR TITLE
Add video review page with snapshot capture and navigation

### DIFF
--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -8,7 +8,7 @@
 3. 视频 Range 流式播放（支持拖动 / 极速加载）。
 """
 
-import os, shutil, hashlib, mimetypes, io, zipfile
+import os, shutil, hashlib, mimetypes, io, zipfile, base64
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from flask import (
@@ -144,6 +144,11 @@ def thumb_path(album: str, filename: str) -> str:
     os.makedirs(d, exist_ok=True)
     return os.path.join(d, filename + ".jpg")
 
+def snapshot_dir(album: str, filename: str) -> str:
+    d = os.path.join(UPLOAD_ROOT, album, ".review", filename)
+    os.makedirs(d, exist_ok=True)
+    return d
+
 # ---------- Range 流式播放 ----------
 
 def partial_response(path: str, mime: str):
@@ -223,6 +228,92 @@ def preview(album_name, filename):
         except Exception:
             pass
     return send_file(src)
+
+@app.route("/<album_name>/review/<path:filename>")
+def review(album_name, filename):
+    album = safe_album(album_name)
+    if not album:
+        abort(404)
+    fname = sanitize_filename(filename)
+    path = os.path.join(UPLOAD_ROOT, album, fname)
+    if not os.path.isfile(path):
+        abort(404)
+    ext = os.path.splitext(fname)[1].lower()
+    if ext not in VIDEO_EXTS:
+        abort(404)
+    return render_template('review.html', album=album, filename=fname)
+
+@app.route("/<album_name>/review/<path:filename>/snapshots", methods=['GET','POST'])
+def review_snapshots(album_name, filename):
+    album = safe_album(album_name)
+    if not album:
+        abort(404)
+    fname = sanitize_filename(filename)
+    src = os.path.join(UPLOAD_ROOT, album, fname)
+    if not os.path.isfile(src):
+        abort(404)
+    d = snapshot_dir(album, fname)
+    if request.method == 'GET':
+        items = []
+        for n in os.listdir(d):
+            if n.lower().endswith('.jpg'):
+                try:
+                    t = float(os.path.splitext(n)[0])
+                except Exception:
+                    t = 0.0
+                items.append({'name': n, 'time': t})
+        items.sort(key=lambda x: x['time'])
+        return jsonify(items)
+    data = request.get_json(force=True)
+    b64 = data.get('image', '')
+    t = float(data.get('time', 0))
+    if ',' in b64:
+        b64 = b64.split(',', 1)[1]
+    img = base64.b64decode(b64)
+    name = f"{t:.3f}.jpg"
+    with open(os.path.join(d, name), 'wb') as f:
+        f.write(img)
+    return jsonify({'ok': True, 'name': name, 'time': t})
+
+@app.route("/<album_name>/review/<path:filename>/snapshots/<snap_name>")
+def review_snapshot_file(album_name, filename, snap_name):
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    snap = sanitize_filename(snap_name)
+    path = os.path.join(snapshot_dir(album, fname), snap)
+    if not os.path.isfile(path):
+        abort(404)
+    return send_file(path, mimetype='image/jpeg')
+
+@app.route("/<album_name>/review/<path:filename>/snapshots/<snap_name>/rename", methods=['POST'])
+def review_snapshot_rename(album_name, filename, snap_name):
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    snap = sanitize_filename(snap_name)
+    data = request.get_json(force=True)
+    new = sanitize_filename(data.get('name', ''))
+    if not new.lower().endswith('.jpg'):
+        new += '.jpg'
+    d = snapshot_dir(album, fname)
+    src = os.path.join(d, snap)
+    dst = os.path.join(d, new)
+    if not os.path.isfile(src):
+        abort(404)
+    if os.path.isfile(dst):
+        return jsonify({'ok': False, 'msg': 'exists'}), 400
+    os.rename(src, dst)
+    return jsonify({'ok': True, 'name': new})
+
+@app.route("/<album_name>/review/<path:filename>/snapshots/<snap_name>/delete", methods=['POST'])
+def review_snapshot_delete(album_name, filename, snap_name):
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    snap = sanitize_filename(snap_name)
+    d = snapshot_dir(album, fname)
+    path = os.path.join(d, snap)
+    if os.path.isfile(path):
+        os.remove(path)
+    return jsonify({'ok': True})
 
 @app.route("/<album_name>/download/<path:filename>")
 def download_file_get(album_name, filename):

--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -315,6 +315,19 @@ def review_snapshot_delete(album_name, filename, snap_name):
         os.remove(path)
     return jsonify({'ok': True})
 
+@app.route("/<album_name>/review/<path:filename>/snapshots/delete_all", methods=['POST'])
+def review_snapshot_delete_all(album_name, filename):
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    d = snapshot_dir(album, fname)
+    for n in os.listdir(d):
+        if n.lower().endswith('.jpg'):
+            try:
+                os.remove(os.path.join(d, n))
+            except FileNotFoundError:
+                pass
+    return jsonify({'ok': True})
+
 @app.route("/<album_name>/download/<path:filename>")
 def download_file_get(album_name, filename):
     album=safe_album(album_name)

--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -470,6 +470,13 @@ def rename_file(album_name):
     tp_new = thumb_path(album, newname)
     if os.path.isfile(tp_old):
         os.rename(tp_old, tp_new)
+    rev_old = os.path.join(UPLOAD_ROOT, album, '.review', old)
+    rev_new = os.path.join(UPLOAD_ROOT, album, '.review', newname)
+    if os.path.isdir(rev_old):
+        try:
+            os.rename(rev_old, rev_new)
+        except OSError:
+            pass
     return jsonify({'ok': True, 'new': newname})
 
 

--- a/templates/album.html
+++ b/templates/album.html
@@ -71,7 +71,9 @@
 {% endif %}{% endwith %}
 <div class='grid'>
 {% for f in files %}{% set ext=f.name.split('.')[-1]|lower %}<figure>{% if ext in ['mp4','webm','ogg','avi','mov','mkv'] %}
-  <video src='{{ url_for("stream", album_name=album, filename=f.name) }}#t=0.1' preload='metadata' muted onclick="location.href='{{ url_for('review', album_name=album, filename=f.name) }}'"></video>
+  <a href='{{ url_for('review', album_name=album, filename=f.name) }}' target='_blank'>
+    <video src='{{ url_for("stream", album_name=album, filename=f.name) }}#t=0.1' preload='metadata' muted></video>
+  </a>
 {% elif ext in ['dng','raw','nef','cr2','arw','rw2'] %}
   <img src='{{ url_for("thumb", album_name=album, filename=f.name) }}' data-full='{{ url_for("preview", album_name=album, filename=f.name) }}' onclick='showImage(this)'>
 {% else %}

--- a/templates/album.html
+++ b/templates/album.html
@@ -71,7 +71,7 @@
 {% endif %}{% endwith %}
 <div class='grid'>
 {% for f in files %}{% set ext=f.name.split('.')[-1]|lower %}<figure>{% if ext in ['mp4','webm','ogg','avi','mov','mkv'] %}
-  <video src='{{ url_for("stream", album_name=album, filename=f.name) }}#t=0.1' data-full='{{ url_for("stream", album_name=album, filename=f.name) }}' preload='metadata' muted onclick='showVideo(this)'></video>
+  <video src='{{ url_for("stream", album_name=album, filename=f.name) }}#t=0.1' preload='metadata' muted onclick="location.href='{{ url_for('review', album_name=album, filename=f.name) }}'"></video>
 {% elif ext in ['dng','raw','nef','cr2','arw','rw2'] %}
   <img src='{{ url_for("thumb", album_name=album, filename=f.name) }}' data-full='{{ url_for("preview", album_name=album, filename=f.name) }}' onclick='showImage(this)'>
 {% else %}
@@ -92,7 +92,6 @@
 <div id='overlay'>
   <button id='prev' class='nav' onclick='event.stopPropagation();prev()'>&lsaquo;</button>
   <img>
-  <video controls style='display:none'></video>
   <button id='next' class='nav' onclick='event.stopPropagation();next()'>&rsaquo;</button>
 </div>
 <script>
@@ -174,16 +173,23 @@ function renameAlbum(){
     body:JSON.stringify({name})
   }).then(r=>r.json()).then(d=>{if(d.ok){location.href='/'+encodeURIComponent(d.new);}else{alert('重命名失败');}});
 }
-const items=[...document.querySelectorAll('.grid img, .grid video')];
+const items=[...document.querySelectorAll('.grid img')];
 let idx=-1,scale=1,offX=0,offY=0;
 function updateTransform(){
   const img=document.querySelector('#overlay img');
   img.style.transform=`translate(${offX}px,${offY}px) scale(${scale})`;
 }
-function showAt(i){if(i<0||i>=items.length)return;idx=i;scale=1;offX=0;offY=0;const it=items[i];const o=document.getElementById('overlay');const img=o.querySelector('img');const v=o.querySelector('video');if(it.tagName.toLowerCase()==='video'){img.style.display='none';img.src='';v.style.display='block';v.src=it.dataset.full;o.style.display='flex';v.play();}else{v.pause();v.style.display='none';v.src='';img.style.display='block';img.src=it.dataset.full;o.style.display='flex';updateTransform();}}
+function showAt(i){
+  if(i<0||i>=items.length)return;
+  idx=i;scale=1;offX=0;offY=0;
+  const o=document.getElementById('overlay');
+  const img=o.querySelector('img');
+  img.src=items[i].dataset.full;
+  o.style.display='flex';
+  updateTransform();
+}
 function showImage(el){showAt(items.indexOf(el));}
-function showVideo(el){showAt(items.indexOf(el));}
-function hide(){const o=document.getElementById('overlay');o.style.display='none';const v=o.querySelector('video');v.pause();v.src='';idx=-1;}
+function hide(){const o=document.getElementById('overlay');o.style.display='none';idx=-1;}
 function next(){if(idx<items.length-1)showAt(idx+1);}
 function prev(){if(idx>0)showAt(idx-1);}
 document.addEventListener('keydown',e=>{const o=document.getElementById('overlay');if(o.style.display!=='flex')return;if(e.key==='ArrowRight'){next();e.preventDefault();}else if(e.key==='ArrowLeft'){prev();e.preventDefault();}});
@@ -213,7 +219,7 @@ document.addEventListener('mouseup',()=>{
   dragging=false;
   imgEl.classList.remove('dragging');
 });
-overlay.addEventListener('wheel',e=>{if(imgEl.style.display==='none')return;e.preventDefault();const rect=imgEl.getBoundingClientRect();const cx=e.clientX-(rect.left+rect.width/2);const cy=e.clientY-(rect.top+rect.height/2);const old=scale;scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);const ratio=scale/old;offX-=cx*(ratio-1);offY-=cy*(ratio-1);updateTransform();},{passive:false});
+overlay.addEventListener('wheel',e=>{e.preventDefault();const rect=imgEl.getBoundingClientRect();const cx=e.clientX-(rect.left+rect.width/2);const cy=e.clientY-(rect.top+rect.height/2);const old=scale;scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);const ratio=scale/old;offX-=cx*(ratio-1);offY-=cy*(ratio-1);updateTransform();},{passive:false});
 </script>
 </body>
 </html>

--- a/templates/review.html
+++ b/templates/review.html
@@ -7,7 +7,8 @@
   <style>
     body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
     #video{flex:1;background:#000;}
-    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;}
+    #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;}
+    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;}
     #help{font-size:.85rem;margin-bottom:8px;color:#333;}
     #list{display:flex;flex-direction:column;gap:8px;}
     .shot{display:flex;align-items:center;gap:4px;}
@@ -25,6 +26,7 @@
 </head>
 <body>
   <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
+  <div id='divider'></div>
   <div id='shots'>
     <div id='help'>快捷键: F/D/S/A 后退0.5/1/3/5秒，J/K/L/; 前进0.5/1/3/5秒，空格 播放/暂停，回车 保存截图</div>
     <div id='list'></div>
@@ -36,13 +38,14 @@
   </div>
 <script>
 const video=document.getElementById('video');
+const divider=document.getElementById('divider');
 const snapUrl='/' + encodeURIComponent('{{ album }}') + '/review/' + encodeURIComponent('{{ filename }}') + '/snapshots';
 const shots=document.getElementById('list');
 const items=[];
-let idx=-1,scale=1,offX=0,offY=0;
+let idx=-1,scale=1,offX=0,offY=0,splitDrag=false;
 function seek(d){video.currentTime=Math.max(0,video.currentTime+d);}
-document.addEventListener('keydown',e=>{
-  if(e.target.tagName==='INPUT')return;
+function handleKey(e){
+  if(e.target.tagName==='INPUT' && e.target.type==='text')return;
   const k=e.key.toLowerCase();
   if(k==='f')seek(-0.5);
   else if(k==='d')seek(-1);
@@ -54,7 +57,17 @@ document.addEventListener('keydown',e=>{
   else if(k===';'||k===':')seek(5);
   else if(e.code==='Space'){e.preventDefault();video.paused?video.play():video.pause();}
   else if(e.key==='Enter'){e.preventDefault();capture();}
+}
+document.addEventListener('keydown',handleKey,true);
+divider.addEventListener('mousedown',e=>{splitDrag=true;document.body.style.userSelect='none';e.preventDefault();});
+document.addEventListener('mousemove',e=>{
+  if(!splitDrag)return;
+  const w=window.innerWidth-e.clientX;
+  const min=200,max=window.innerWidth-200;
+  const width=Math.min(Math.max(w,min),max);
+  document.getElementById('shots').style.width=width+'px';
 });
+document.addEventListener('mouseup',()=>{splitDrag=false;document.body.style.userSelect='';});
 async function capture(){
   const c=document.createElement('canvas');
   c.width=video.videoWidth;c.height=video.videoHeight;

--- a/templates/review.html
+++ b/templates/review.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang='zh-CN'>
+<head>
+  <meta charset='utf-8'>
+  <title>{{ filename }} - Review</title>
+  <meta name='viewport' content='width=device-width,initial-scale=1'>
+  <style>
+    body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
+    #video{flex:1;background:#000;}
+    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;gap:8px;}
+    .shot{display:flex;align-items:center;gap:4px;}
+    .shot img{width:80px;height:45px;object-fit:cover;cursor:pointer;border-radius:4px;}
+    .shot .time{font-size:.8rem;}
+    .shot button{margin-left:2px;}
+  </style>
+</head>
+<body>
+  <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
+  <div id='shots'></div>
+<script>
+const video=document.getElementById('video');
+const snapUrl='/' + encodeURIComponent('{{ album }}') + '/review/' + encodeURIComponent('{{ filename }}') + '/snapshots';
+function seek(d){video.currentTime=Math.max(0,video.currentTime+d);}
+document.addEventListener('keydown',e=>{
+  if(e.target.tagName==='INPUT')return;
+  const k=e.key.toLowerCase();
+  if(k==='f')seek(-0.5);
+  else if(k==='d')seek(-1);
+  else if(k==='s')seek(-3);
+  else if(k==='a')seek(-5);
+  else if(k==='j')seek(0.5);
+  else if(k==='k')seek(1);
+  else if(k==='l')seek(3);
+  else if(k===';'||k===':')seek(5);
+  else if(e.code==='Space'){e.preventDefault();video.paused?video.play():video.pause();}
+  else if(e.key==='Enter'){capture();}
+});
+async function capture(){
+  const c=document.createElement('canvas');
+  c.width=video.videoWidth;c.height=video.videoHeight;
+  c.getContext('2d').drawImage(video,0,0,c.width,c.height);
+  const data=c.toDataURL('image/jpeg');
+  const t=video.currentTime;
+  const res=await fetch(snapUrl,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({time:t,image:data})});
+  const info=await res.json();
+  if(info.ok)addShot(info.name,t);
+}
+async function loadShots(){
+  const res=await fetch(snapUrl);
+  const arr=await res.json();
+  arr.forEach(s=>addShot(s.name,s.time));
+}
+function addShot(name,time){
+  const div=document.createElement('div');div.className='shot';
+  const img=document.createElement('img');img.src=`${snapUrl}/${name}`;img.onclick=()=>window.open(img.src,'_blank');
+  const span=document.createElement('span');span.className='time';span.dataset.t=time;span.textContent=time.toFixed(2)+'s';
+  const jump=document.createElement('button');jump.textContent='跳转';jump.onclick=()=>{video.currentTime=time;};
+  const rename=document.createElement('button');rename.textContent='改名';rename.onclick=async()=>{
+    const nn=prompt('新名称',name);if(!nn)return;
+    const r=await fetch(`${snapUrl}/${encodeURIComponent(name)}/rename`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:nn})});
+    const d=await r.json();if(d.ok){name=d.name;img.src=`${snapUrl}/${name}`;}
+  };
+  const del=document.createElement('button');del.textContent='删除';del.onclick=async()=>{
+    if(!confirm('删除?'))return;
+    await fetch(`${snapUrl}/${encodeURIComponent(name)}/delete`,{method:'POST'});
+    div.remove();
+  };
+  div.append(img,span,jump,rename,del);
+  const shots=document.getElementById('shots');
+  shots.appendChild(div);
+  [...shots.children].sort((a,b)=>parseFloat(a.querySelector('.time').dataset.t)-parseFloat(b.querySelector('.time').dataset.t)).forEach(n=>shots.appendChild(n));
+}
+loadShots();
+</script>
+</body>
+</html>

--- a/templates/review.html
+++ b/templates/review.html
@@ -6,10 +6,10 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <style>
     :root{--primary:#1976d2;}
-    body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;align-items:flex-start;height:100vh;}
-    #player{flex:1;display:flex;flex-direction:column;align-items:center;}
-    #videoWrap{display:flex;align-items:center;justify-content:center;background:#000;}
-    #video{max-width:100%;max-height:100%;height:auto;width:auto;}
+    body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
+    #player{flex:1;display:flex;flex-direction:column;height:100vh;}
+    #videoWrap{flex:1;display:flex;align-items:center;justify-content:center;background:#000;width:100%;}
+    #video{width:100%;height:100%;object-fit:contain;}
     #controls{display:flex;flex-wrap:wrap;gap:4px;justify-content:center;padding:4px;background:#222;width:100%;}
     #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;height:100vh;}
     #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;height:100vh;}

--- a/templates/review.html
+++ b/templates/review.html
@@ -6,13 +6,13 @@
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <style>
     :root{--primary:#1976d2;}
-    body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
-    #player{flex:1;display:flex;flex-direction:column;}
-    #videoWrap{flex:1;display:flex;align-items:center;justify-content:center;background:#000;}
-    #video{max-width:100%;max-height:100%;}
-    #controls{display:flex;flex-wrap:wrap;gap:4px;justify-content:center;padding:4px;background:#222;}
-    #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;}
-    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;}
+    body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;align-items:flex-start;height:100vh;}
+    #player{flex:1;display:flex;flex-direction:column;align-items:center;}
+    #videoWrap{display:flex;align-items:center;justify-content:center;background:#000;}
+    #video{max-width:100%;max-height:100%;height:auto;width:auto;}
+    #controls{display:flex;flex-wrap:wrap;gap:4px;justify-content:center;padding:4px;background:#222;width:100%;}
+    #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;height:100vh;}
+    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;height:100vh;}
     #toolbar{margin-bottom:8px;text-align:right;}
     #help{font-size:.85rem;margin-bottom:8px;color:#333;}
     #list{display:flex;flex-direction:column;gap:8px;}

--- a/templates/review.html
+++ b/templates/review.html
@@ -8,7 +8,8 @@
     :root{--primary:#1976d2;}
     body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
     #player{flex:1;display:flex;flex-direction:column;}
-    #video{flex:1;background:#000;}
+    #videoWrap{flex:1;display:flex;align-items:center;justify-content:center;background:#000;}
+    #video{max-width:100%;max-height:100%;}
     #controls{display:flex;flex-wrap:wrap;gap:4px;justify-content:center;padding:4px;background:#222;}
     #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;}
     #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;}
@@ -32,7 +33,9 @@
 </head>
 <body>
   <div id='player'>
-    <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
+    <div id='videoWrap'>
+      <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
+    </div>
     <div id='controls'>
       <button class='btn' data-seek='-5'>-5s</button>
       <button class='btn' data-seek='-3'>-3s</button>

--- a/templates/review.html
+++ b/templates/review.html
@@ -7,7 +7,9 @@
   <style>
     :root{--primary:#1976d2;}
     body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
+    #player{flex:1;display:flex;flex-direction:column;}
     #video{flex:1;background:#000;}
+    #controls{display:flex;flex-wrap:wrap;gap:4px;justify-content:center;padding:4px;background:#222;}
     #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;}
     #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;}
     #toolbar{margin-bottom:8px;text-align:right;}
@@ -29,7 +31,21 @@
   </style>
 </head>
 <body>
-  <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
+  <div id='player'>
+    <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
+    <div id='controls'>
+      <button class='btn' data-seek='-5'>-5s</button>
+      <button class='btn' data-seek='-3'>-3s</button>
+      <button class='btn' data-seek='-1'>-1s</button>
+      <button class='btn' data-seek='-0.5'>-0.5s</button>
+      <button id='pauseBtn' class='btn'>播放</button>
+      <button id='shotBtn' class='btn'>截图</button>
+      <button class='btn' data-seek='0.5'>+0.5s</button>
+      <button class='btn' data-seek='1'>+1s</button>
+      <button class='btn' data-seek='3'>+3s</button>
+      <button class='btn' data-seek='5'>+5s</button>
+    </div>
+  </div>
   <div id='divider'></div>
   <div id='shots'>
     <div id='toolbar'><button id='delAll' class='btn'>全部删除</button></div>
@@ -47,6 +63,14 @@ const divider=document.getElementById('divider');
 const snapUrl='/' + encodeURIComponent('{{ album }}') + '/review/' + encodeURIComponent('{{ filename }}') + '/snapshots';
 const shots=document.getElementById('list');
 const items=[];
+document.querySelectorAll('#controls [data-seek]').forEach(btn=>btn.addEventListener('click',()=>seek(parseFloat(btn.dataset.seek))));
+const pauseBtn=document.getElementById('pauseBtn');
+function updatePause(){pauseBtn.textContent=video.paused?'播放':'暂停';}
+pauseBtn.addEventListener('click',()=>{video.paused?video.play():video.pause();});
+video.addEventListener('play',updatePause);
+video.addEventListener('pause',updatePause);
+updatePause();
+document.getElementById('shotBtn').addEventListener('click',capture);
 document.getElementById('delAll').onclick=async()=>{
   if(!confirm('全部删除?'))return;
   await fetch(snapUrl+'/delete_all',{method:'POST'});

--- a/templates/review.html
+++ b/templates/review.html
@@ -12,7 +12,7 @@
     #list{display:flex;flex-direction:column;gap:8px;}
     .shot{display:flex;align-items:center;gap:4px;}
     .shot img{width:80px;height:80px;object-fit:cover;cursor:pointer;border-radius:4px;}
-    .shot .name{flex:1;cursor:pointer;font-size:.8rem;}
+    .shot .name{flex:1;cursor:pointer;font-size:.8rem;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
     .shot .time{font-size:.8rem;margin-left:4px;}
     .shot button{margin-left:2px;}
     #overlay{position:fixed;inset:0;display:none;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:999;}
@@ -53,7 +53,7 @@ document.addEventListener('keydown',e=>{
   else if(k==='l')seek(3);
   else if(k===';'||k===':')seek(5);
   else if(e.code==='Space'){e.preventDefault();video.paused?video.play():video.pause();}
-  else if(e.key==='Enter'){capture();}
+  else if(e.key==='Enter'){e.preventDefault();capture();}
 });
 async function capture(){
   const c=document.createElement('canvas');

--- a/templates/review.html
+++ b/templates/review.html
@@ -9,12 +9,14 @@
     #video{flex:1;background:#000;}
     #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;}
     #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;}
+    #toolbar{margin-bottom:8px;text-align:right;}
     #help{font-size:.85rem;margin-bottom:8px;color:#333;}
     #list{display:flex;flex-direction:column;gap:8px;}
     .shot{display:flex;align-items:center;gap:4px;}
     .shot img{width:80px;height:80px;object-fit:cover;cursor:pointer;border-radius:4px;}
-    .shot .name{flex:1;cursor:pointer;font-size:.8rem;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-    .shot .time{font-size:.8rem;margin-left:4px;}
+    .shot .info{flex:1;display:flex;align-items:center;gap:4px;cursor:pointer;}
+    .shot .name{flex:1;font-size:.8rem;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+    .shot .time{font-size:.8rem;}
     .shot button{margin-left:2px;}
     #overlay{position:fixed;inset:0;display:none;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:999;}
     #overlay img{max-width:90vw;max-height:90vh;border-radius:6px;transition:transform .2s;}
@@ -28,6 +30,7 @@
   <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
   <div id='divider'></div>
   <div id='shots'>
+    <div id='toolbar'><button id='delAll'>全部删除</button></div>
     <div id='help'>快捷键: F/D/S/A 后退0.5/1/3/5秒，J/K/L/; 前进0.5/1/3/5秒，空格 播放/暂停，回车 保存截图</div>
     <div id='list'></div>
   </div>
@@ -42,6 +45,12 @@ const divider=document.getElementById('divider');
 const snapUrl='/' + encodeURIComponent('{{ album }}') + '/review/' + encodeURIComponent('{{ filename }}') + '/snapshots';
 const shots=document.getElementById('list');
 const items=[];
+document.getElementById('delAll').onclick=async()=>{
+  if(!confirm('全部删除?'))return;
+  await fetch(snapUrl+'/delete_all',{method:'POST'});
+  shots.innerHTML='';
+  refreshItems();
+};
 let idx=-1,scale=1,offX=0,offY=0,splitDrag=false;
 function seek(d){video.currentTime=Math.max(0,video.currentTime+d);}
 function handleKey(e){
@@ -126,20 +135,28 @@ function addShot(name,time){
   let currentName=name;
   const div=document.createElement('div');div.className='shot';
   const img=document.createElement('img');img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;img.onclick=()=>showImage(img);
+  const info=document.createElement('div');info.className='info';
   const nameSpan=document.createElement('span');nameSpan.className='name';nameSpan.textContent=currentName;
-  nameSpan.addEventListener('click',()=>startEdit(nameSpan,async(old,val)=>{
-    const nn=await renameShot(currentName,val);
-    if(nn){currentName=nn;nameSpan.textContent=nn;img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;}
-  }));
   const timeSpan=document.createElement('span');timeSpan.className='time';timeSpan.dataset.t=time;timeSpan.textContent=time.toFixed(2)+'s';
-  const jump=document.createElement('button');jump.textContent='跳转';jump.onclick=()=>{video.currentTime=time;};
+  info.append(nameSpan,timeSpan);
+  let clickTimer=null;
+  info.addEventListener('click',()=>{
+    clickTimer=setTimeout(()=>{video.currentTime=time;clickTimer=null;},200);
+  });
+  info.addEventListener('dblclick',()=>{
+    if(clickTimer){clearTimeout(clickTimer);clickTimer=null;}
+    startEdit(nameSpan,async(old,val)=>{
+      const nn=await renameShot(currentName,val);
+      if(nn){currentName=nn;nameSpan.textContent=nn;img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;}
+    });
+  });
   const del=document.createElement('button');del.textContent='删除';del.onclick=async()=>{
     if(!confirm('删除?'))return;
     await fetch(`${snapUrl}/${encodeURIComponent(currentName)}/delete`,{method:'POST'});
     div.remove();
     refreshItems();
   };
-  div.append(img,nameSpan,timeSpan,jump,del);
+  div.append(img,info,del);
   shots.appendChild(div);
   sortShots();
 }

--- a/templates/review.html
+++ b/templates/review.html
@@ -7,19 +7,39 @@
   <style>
     body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
     #video{flex:1;background:#000;}
-    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;gap:8px;}
+    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;}
+    #help{font-size:.85rem;margin-bottom:8px;color:#333;}
+    #list{display:flex;flex-direction:column;gap:8px;}
     .shot{display:flex;align-items:center;gap:4px;}
-    .shot img{width:80px;height:45px;object-fit:cover;cursor:pointer;border-radius:4px;}
-    .shot .time{font-size:.8rem;}
+    .shot img{width:80px;height:80px;object-fit:cover;cursor:pointer;border-radius:4px;}
+    .shot .name{flex:1;cursor:pointer;font-size:.8rem;}
+    .shot .time{font-size:.8rem;margin-left:4px;}
     .shot button{margin-left:2px;}
+    #overlay{position:fixed;inset:0;display:none;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:999;}
+    #overlay img{max-width:90vw;max-height:90vh;border-radius:6px;transition:transform .2s;}
+    #overlay img.dragging{transition:none;}
+    #overlay .nav{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);border:none;color:#fff;font-size:2rem;padding:.5rem;border-radius:50%;cursor:pointer;user-select:none;}
+    #overlay #prev{left:1rem;}
+    #overlay #next{right:1rem;}
   </style>
 </head>
 <body>
   <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
-  <div id='shots'></div>
+  <div id='shots'>
+    <div id='help'>快捷键: F/D/S/A 后退0.5/1/3/5秒，J/K/L/; 前进0.5/1/3/5秒，空格 播放/暂停，回车 保存截图</div>
+    <div id='list'></div>
+  </div>
+  <div id='overlay'>
+    <button id='prev' class='nav' onclick='event.stopPropagation();prev()'>&lsaquo;</button>
+    <img>
+    <button id='next' class='nav' onclick='event.stopPropagation();next()'>&rsaquo;</button>
+  </div>
 <script>
 const video=document.getElementById('video');
 const snapUrl='/' + encodeURIComponent('{{ album }}') + '/review/' + encodeURIComponent('{{ filename }}') + '/snapshots';
+const shots=document.getElementById('list');
+const items=[];
+let idx=-1,scale=1,offX=0,offY=0;
 function seek(d){video.currentTime=Math.max(0,video.currentTime+d);}
 document.addEventListener('keydown',e=>{
   if(e.target.tagName==='INPUT')return;
@@ -50,26 +70,90 @@ async function loadShots(){
   const arr=await res.json();
   arr.forEach(s=>addShot(s.name,s.time));
 }
-function addShot(name,time){
-  const div=document.createElement('div');div.className='shot';
-  const img=document.createElement('img');img.src=`${snapUrl}/${name}`;img.onclick=()=>window.open(img.src,'_blank');
-  const span=document.createElement('span');span.className='time';span.dataset.t=time;span.textContent=time.toFixed(2)+'s';
-  const jump=document.createElement('button');jump.textContent='跳转';jump.onclick=()=>{video.currentTime=time;};
-  const rename=document.createElement('button');rename.textContent='改名';rename.onclick=async()=>{
-    const nn=prompt('新名称',name);if(!nn)return;
-    const r=await fetch(`${snapUrl}/${encodeURIComponent(name)}/rename`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:nn})});
-    const d=await r.json();if(d.ok){name=d.name;img.src=`${snapUrl}/${name}`;}
+function refreshItems(){items.splice(0,items.length,...document.querySelectorAll('#list img'));}
+function sortShots(){
+  [...shots.children].sort((a,b)=>parseFloat(a.querySelector('.time').dataset.t)-parseFloat(b.querySelector('.time').dataset.t)).forEach(n=>shots.appendChild(n));
+  refreshItems();
+}
+async function renameShot(oldName,newName){
+  const r=await fetch(`${snapUrl}/${encodeURIComponent(oldName)}/rename`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:newName})});
+  const d=await r.json();
+  if(d.ok)return d.name;
+  alert('改名失败');
+  return null;
+}
+function startEdit(span,cb){
+  if(span.dataset.editing)return;
+  span.dataset.editing='1';
+  const old=span.textContent;
+  const input=document.createElement('input');
+  input.type='text';
+  input.value=old;
+  input.style.width='100%';
+  span.replaceWith(input);
+  input.focus();
+  input.select();
+  const finish=async(doRename)=>{
+    input.replaceWith(span);
+    span.dataset.editing='';
+    const val=input.value.trim();
+    if(doRename&&val&&val!==old){
+      await cb(old,val);
+    }else{
+      span.textContent=old;
+    }
   };
+  input.addEventListener('blur',()=>finish(true));
+  input.addEventListener('keydown',e=>{
+    if(e.key==='Enter'){input.blur();}
+    else if(e.key==='Escape'){input.value=old;finish(false);}
+  });
+}
+function addShot(name,time){
+  let currentName=name;
+  const div=document.createElement('div');div.className='shot';
+  const img=document.createElement('img');img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;img.onclick=()=>showImage(img);
+  const nameSpan=document.createElement('span');nameSpan.className='name';nameSpan.textContent=currentName;
+  nameSpan.addEventListener('click',()=>startEdit(nameSpan,async(old,val)=>{
+    const nn=await renameShot(currentName,val);
+    if(nn){currentName=nn;nameSpan.textContent=nn;img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;}
+  }));
+  const timeSpan=document.createElement('span');timeSpan.className='time';timeSpan.dataset.t=time;timeSpan.textContent=time.toFixed(2)+'s';
+  const jump=document.createElement('button');jump.textContent='跳转';jump.onclick=()=>{video.currentTime=time;};
   const del=document.createElement('button');del.textContent='删除';del.onclick=async()=>{
     if(!confirm('删除?'))return;
-    await fetch(`${snapUrl}/${encodeURIComponent(name)}/delete`,{method:'POST'});
+    await fetch(`${snapUrl}/${encodeURIComponent(currentName)}/delete`,{method:'POST'});
     div.remove();
+    refreshItems();
   };
-  div.append(img,span,jump,rename,del);
-  const shots=document.getElementById('shots');
+  div.append(img,nameSpan,timeSpan,jump,del);
   shots.appendChild(div);
-  [...shots.children].sort((a,b)=>parseFloat(a.querySelector('.time').dataset.t)-parseFloat(b.querySelector('.time').dataset.t)).forEach(n=>shots.appendChild(n));
+  sortShots();
 }
+function showAt(i){
+  if(i<0||i>=items.length)return;
+  idx=i;scale=1;offX=0;offY=0;
+  const o=document.getElementById('overlay');
+  const img=o.querySelector('img');
+  img.src=items[i].dataset.full;
+  o.style.display='flex';
+  updateTransform();
+}
+function showImage(el){showAt(items.indexOf(el));}
+function hide(){const o=document.getElementById('overlay');o.style.display='none';idx=-1;}
+function next(){if(idx<items.length-1)showAt(idx+1);}
+function prev(){if(idx>0)showAt(idx-1);}
+function updateTransform(){const img=document.querySelector('#overlay img');img.style.transform=`translate(${offX}px,${offY}px) scale(${scale})`;}
+document.addEventListener('keydown',e=>{const o=document.getElementById('overlay');if(o.style.display!=='flex')return;if(e.key==='ArrowRight'){next();e.preventDefault();}else if(e.key==='ArrowLeft'){prev();e.preventDefault();}});
+const overlay=document.getElementById('overlay');
+const imgEl=document.querySelector('#overlay img');
+let dragging=false,lastX=0,lastY=0;
+imgEl.addEventListener('mousedown',e=>{if(e.button!==0)return;dragging=true;imgEl.classList.add('dragging');lastX=e.clientX;lastY=e.clientY;e.preventDefault();e.stopPropagation();});
+imgEl.addEventListener('click',e=>e.stopPropagation());
+overlay.addEventListener('click',e=>{if(e.target===overlay)hide();});
+document.addEventListener('mousemove',e=>{if(!dragging)return;offX+=e.clientX-lastX;offY+=e.clientY-lastY;lastX=e.clientX;lastY=e.clientY;updateTransform();});
+document.addEventListener('mouseup',()=>{dragging=false;imgEl.classList.remove('dragging');});
+overlay.addEventListener('wheel',e=>{e.preventDefault();const rect=imgEl.getBoundingClientRect();const cx=e.clientX-(rect.left+rect.width/2);const cy=e.clientY-(rect.top+rect.height/2);const old=scale;scale+=e.deltaY<0?0.1:-0.1;scale=Math.min(Math.max(scale,1),5);const ratio=scale/old;offX-=cx*(ratio-1);offY-=cy*(ratio-1);updateTransform();},{passive:false});
 loadShots();
 </script>
 </body>

--- a/templates/review.html
+++ b/templates/review.html
@@ -57,6 +57,7 @@ let idx=-1,scale=1,offX=0,offY=0,splitDrag=false;
 function seek(d){video.currentTime=Math.max(0,video.currentTime+d);}
 function handleKey(e){
   if(e.target.tagName==='INPUT' && e.target.type==='text')return;
+  e.stopPropagation();
   const k=e.key.toLowerCase();
   if(k==='f')seek(-0.5);
   else if(k==='d')seek(-1);
@@ -67,7 +68,7 @@ function handleKey(e){
   else if(k==='l')seek(3);
   else if(k===';'||k===':')seek(5);
   else if(e.code==='Space'){e.preventDefault();video.paused?video.play():video.pause();}
-  else if(e.key==='Enter'){e.preventDefault();capture();}
+  else if(e.key==='Enter'){e.preventDefault();capture();document.activeElement.blur();}
 }
 document.addEventListener('keydown',handleKey,true);
 divider.addEventListener('mousedown',e=>{splitDrag=true;document.body.style.userSelect='none';e.preventDefault();});

--- a/templates/review.html
+++ b/templates/review.html
@@ -5,14 +5,36 @@
   <title>{{ filename }} - Review</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <style>
+    *, *::before, *::after { box-sizing: border-box; }
     :root{--primary:#1976d2;}
-    body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
-    #player{flex:1;display:flex;flex-direction:column;height:100vh;}
-    #videoWrap{flex:1;display:flex;align-items:center;justify-content:center;background:#000;width:100%;}
-    #video{width:100%;height:100%;object-fit:contain;}
+    body{ margin:0; font-family:system-ui,Arial,sans-serif; display:flex; height:100dvh; }
+    #player{
+  flex:1; display:flex; flex-direction:column;
+  /* 删掉 height:100vh; 让它继承父容器高度 */
+  min-height:0; /* 2) 关键：允许子项在 flex 中被压缩 */
+}
+
+#videoWrap{
+  flex:1; display:flex; align-items:center; justify-content:center;
+  background:#000; width:100%;
+  min-height:0;     /* 2) 同理，防止被视频控件撑高 */
+  overflow:hidden;  /* 细节：缩放/contain 时不溢出 */
+}
+
+/* 3) 约束 video，不强行 height:100% */
+#video{
+  max-width:100%;
+  max-height:100%;
+  width:100%;
+  height:auto;          /* 关键：让浏览器按比例算高，控件也不会再额外挤出 */
+  object-fit:contain;
+}
     #controls{display:flex;flex-wrap:wrap;gap:4px;justify-content:center;padding:4px;background:#222;width:100%;}
-    #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;height:100vh;}
-    #shots{width:300px;overflow-y:auto;border-left:1px solid #ccc;padding:8px;display:flex;flex-direction:column;flex:none;height:100vh;}
+    #divider{ width:4px; background:#ddd; cursor:col-resize; flex:none; height:100dvh; }
+    #shots{
+  width:300px; overflow-y:auto; border-left:1px solid #ccc; padding:8px;
+  display:flex; flex-direction:column; flex:none; height:100dvh; min-height:0;
+}
     #toolbar{margin-bottom:8px;text-align:right;}
     #help{font-size:.85rem;margin-bottom:8px;color:#333;}
     #list{display:flex;flex-direction:column;gap:8px;}

--- a/templates/review.html
+++ b/templates/review.html
@@ -5,6 +5,7 @@
   <title>{{ filename }} - Review</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <style>
+    :root{--primary:#1976d2;}
     body{margin:0;font-family:system-ui,Arial,sans-serif;display:flex;height:100vh;}
     #video{flex:1;background:#000;}
     #divider{width:4px;background:#ddd;cursor:col-resize;flex:none;}
@@ -12,12 +13,13 @@
     #toolbar{margin-bottom:8px;text-align:right;}
     #help{font-size:.85rem;margin-bottom:8px;color:#333;}
     #list{display:flex;flex-direction:column;gap:8px;}
-    .shot{display:flex;align-items:center;gap:4px;}
-    .shot img{width:80px;height:80px;object-fit:cover;cursor:pointer;border-radius:4px;}
-    .shot .info{flex:1;display:flex;align-items:center;gap:4px;cursor:pointer;}
-    .shot .name{flex:1;font-size:.8rem;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+    .shot{display:flex;align-items:center;gap:4px;cursor:pointer;}
+    .shot img{width:80px;height:80px;object-fit:contain;background:#000;cursor:pointer;border-radius:4px;}
+    .shot .info{flex:1;display:flex;align-items:center;gap:4px;}
+    .shot .name{flex:1;font-size:.8rem;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;cursor:pointer;}
     .shot .time{font-size:.8rem;}
     .shot button{margin-left:2px;}
+    button,.btn{background:var(--primary);color:#fff;border:none;border-radius:4px;padding:.5rem 1rem;cursor:pointer;font:1rem/1.2 system-ui,Arial,sans-serif;}
     #overlay{position:fixed;inset:0;display:none;background:rgba(0,0,0,.85);align-items:center;justify-content:center;z-index:999;}
     #overlay img{max-width:90vw;max-height:90vh;border-radius:6px;transition:transform .2s;}
     #overlay img.dragging{transition:none;}
@@ -30,7 +32,7 @@
   <video id='video' src='{{ url_for("stream", album_name=album, filename=filename) }}' controls></video>
   <div id='divider'></div>
   <div id='shots'>
-    <div id='toolbar'><button id='delAll'>全部删除</button></div>
+    <div id='toolbar'><button id='delAll' class='btn'>全部删除</button></div>
     <div id='help'>快捷键: F/D/S/A 后退0.5/1/3/5秒，J/K/L/; 前进0.5/1/3/5秒，空格 播放/暂停，回车 保存截图</div>
     <div id='list'></div>
   </div>
@@ -134,28 +136,39 @@ function startEdit(span,cb){
 function addShot(name,time){
   let currentName=name;
   const div=document.createElement('div');div.className='shot';
-  const img=document.createElement('img');img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;img.onclick=()=>showImage(img);
+  const img=document.createElement('img');
+  img.src=`${snapUrl}/${currentName}`;
+  img.dataset.full=img.src;
+  img.addEventListener('click',e=>{e.stopPropagation();showImage(img);});
+
   const info=document.createElement('div');info.className='info';
   const nameSpan=document.createElement('span');nameSpan.className='name';nameSpan.textContent=currentName;
-  const timeSpan=document.createElement('span');timeSpan.className='time';timeSpan.dataset.t=time;timeSpan.textContent=time.toFixed(2)+'s';
-  info.append(nameSpan,timeSpan);
-  let clickTimer=null;
-  info.addEventListener('click',()=>{
-    clickTimer=setTimeout(()=>{video.currentTime=time;clickTimer=null;},200);
-  });
-  info.addEventListener('dblclick',()=>{
-    if(clickTimer){clearTimeout(clickTimer);clickTimer=null;}
+  nameSpan.addEventListener('click',e=>{
+    e.stopPropagation();
     startEdit(nameSpan,async(old,val)=>{
       const nn=await renameShot(currentName,val);
       if(nn){currentName=nn;nameSpan.textContent=nn;img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;}
     });
   });
-  const del=document.createElement('button');del.textContent='删除';del.onclick=async()=>{
+  const timeSpan=document.createElement('span');timeSpan.className='time';timeSpan.dataset.t=time;timeSpan.textContent=time.toFixed(2)+'s';
+  info.append(nameSpan,timeSpan);
+
+  const del=document.createElement('button');
+  del.className='btn';
+  del.textContent='删除';
+  del.addEventListener('click',async e=>{
+    e.stopPropagation();
     if(!confirm('删除?'))return;
     await fetch(`${snapUrl}/${encodeURIComponent(currentName)}/delete`,{method:'POST'});
     div.remove();
     refreshItems();
-  };
+  });
+
+  div.addEventListener('click',e=>{
+    if(e.target===nameSpan||e.target===del||e.target.tagName==='INPUT')return;
+    video.currentTime=time;
+  });
+
   div.append(img,info,del);
   shots.appendChild(div);
   sortShots();

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -80,7 +80,10 @@ def test_rename_invalid(client, album_path):
 def test_rename_file(client, album_path):
     data = {"file": (io.BytesIO(b"x"), "old.jpg")}
     client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    rev = os.path.join(album_path, ".review", "old.jpg")
+    os.makedirs(rev, exist_ok=True)
     resp = client.post(f"/{ALBUM}/rename_file", json={"old": "old.jpg", "new": "new.jpg"})
     assert resp.status_code == 200
     assert os.path.isfile(os.path.join(album_path, "new.jpg"))
+    assert os.path.isdir(os.path.join(album_path, ".review", "new.jpg"))
 


### PR DESCRIPTION
## Summary
- Add `/review` page with keyboard shortcuts to seek, pause, and capture frames from videos
- Store captured frames as snapshots with rename/delete endpoints
- Redirect album video thumbnails to new review page and streamline image overlay

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0be912c4832089077b4d5b5c6968