### PR TITLE
Add snapshot prefix rename and video export

### DIFF
--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -391,9 +391,22 @@ def pack_zip(album_name):
     total=len(files) or 1
     zpath=os.path.join(path, f"{album}.zip")
     def gen():
-        with zipfile.ZipFile(zpath,'w',zipfile.ZIP_DEFLATED) as z:
+        with zipfile.ZipFile(zpath,'w',zipfile.ZIP_DEFLATED) as outer:
             for i,f in enumerate(files,1):
-                z.write(os.path.join(path,f), arcname=f)
+                src=os.path.join(path,f)
+                ext=os.path.splitext(f)[1].lower()
+                if ext in VIDEO_EXTS:
+                    buf=io.BytesIO()
+                    with zipfile.ZipFile(buf,'w',zipfile.ZIP_DEFLATED) as z:
+                        z.write(src, arcname=f)
+                        sdir=os.path.join(path, '.review', f)
+                        if os.path.isdir(sdir):
+                            for n in os.listdir(sdir):
+                                if n.lower().endswith('.jpg'):
+                                    z.write(os.path.join(sdir,n), arcname=n)
+                    outer.writestr(os.path.splitext(f)[0]+'.zip', buf.getvalue())
+                else:
+                    outer.write(src, arcname=f)
                 yield f"data:{i/total:.4f}\n\n"
         yield "data:done\n\n"
     return Response(gen(), mimetype='text/event-stream')
@@ -421,10 +434,20 @@ def album(album_name):
                             continue
                         vname = sanitize_filename(os.path.basename(vids[0]))
                         vdest = os.path.join(path, vname)
+                        if os.path.exists(vdest) and request.args.get('overwrite') != '1':
+                            return jsonify({'ok': False, 'msg': 'exists'}), 409
+                        if os.path.exists(vdest):
+                            os.remove(vdest)
+                        thumb_old = thumb_path(album, vname)
+                        if os.path.exists(thumb_old):
+                            os.remove(thumb_old)
+                        sdir = os.path.join(UPLOAD_ROOT, album, '.review', vname)
+                        if os.path.isdir(sdir):
+                            shutil.rmtree(sdir, ignore_errors=True)
+                        os.makedirs(sdir, exist_ok=True)
                         with z.open(vids[0]) as vf, open(vdest, 'wb') as out:
                             shutil.copyfileobj(vf, out)
                         make_thumb(vdest, thumb_path(album, vname))
-                        sdir = snapshot_dir(album, vname)
                         for n in z.namelist():
                             if n == vids[0] or n.endswith('/'):
                                 continue
@@ -440,6 +463,16 @@ def album(album_name):
                 flash(f'类型不允许: {fname}')
                 continue
             dest=os.path.join(path, fname)
+            if os.path.exists(dest) and request.args.get('overwrite') != '1':
+                return jsonify({'ok': False, 'msg': 'exists'}), 409
+            if os.path.exists(dest):
+                os.remove(dest)
+                tp = thumb_path(album, fname)
+                if os.path.exists(tp):
+                    os.remove(tp)
+                rev = os.path.join(UPLOAD_ROOT, album, '.review', fname)
+                if os.path.isdir(rev):
+                    shutil.rmtree(rev, ignore_errors=True)
             def task(fileobj, d, name):
                 fileobj.save(d)
                 make_thumb(d, thumb_path(album, name))

--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -20,7 +20,8 @@ UPLOAD_ROOT = os.path.abspath("uploads")
 ALLOWED_EXTS = {
     ".jpg", ".jpeg", ".png", ".gif", ".bmp",
     ".dng", ".raw", ".nef", ".cr2", ".arw", ".rw2",
-    ".mp4", ".webm", ".ogg", ".avi", ".mov", ".mkv"
+    ".mp4", ".webm", ".ogg", ".avi", ".mov", ".mkv",
+    ".zip"
 }
 IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".bmp"}
 VIDEO_EXTS = {".mp4", ".webm", ".ogg", ".avi", ".mov", ".mkv"}
@@ -257,8 +258,10 @@ def review_snapshots(album_name, filename):
         items = []
         for n in os.listdir(d):
             if n.lower().endswith('.jpg'):
+                base = os.path.splitext(n)[0]
+                part = base.rsplit('_', 1)[-1]
                 try:
-                    t = float(os.path.splitext(n)[0])
+                    t = float(part)
                 except Exception:
                     t = 0.0
                 items.append({'name': n, 'time': t})
@@ -291,14 +294,16 @@ def review_snapshot_rename(album_name, filename, snap_name):
     fname = sanitize_filename(filename)
     snap = sanitize_filename(snap_name)
     data = request.get_json(force=True)
-    new = sanitize_filename(data.get('name', ''))
-    if not new.lower().endswith('.jpg'):
-        new += '.jpg'
+    prefix = sanitize_filename(data.get('prefix', ''))
     d = snapshot_dir(album, fname)
     src = os.path.join(d, snap)
-    dst = os.path.join(d, new)
     if not os.path.isfile(src):
         abort(404)
+    base = os.path.splitext(snap)[0]
+    part = base.rsplit('_', 1)[-1]
+    new_base = f"{prefix}_{part}" if prefix else part
+    new = new_base + '.jpg'
+    dst = os.path.join(d, new)
     if os.path.isfile(dst):
         return jsonify({'ok': False, 'msg': 'exists'}), 400
     os.rename(src, dst)
@@ -327,6 +332,26 @@ def review_snapshot_delete_all(album_name, filename):
             except FileNotFoundError:
                 pass
     return jsonify({'ok': True})
+
+
+@app.route("/<album_name>/export/<path:filename>")
+def export_video(album_name, filename):
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    path = os.path.join(UPLOAD_ROOT, album, fname)
+    if not os.path.isfile(path) or os.path.splitext(fname)[1].lower() not in VIDEO_EXTS:
+        abort(404)
+    snap_dir = os.path.join(UPLOAD_ROOT, album, '.review', fname)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as z:
+        z.write(path, arcname=fname)
+        if os.path.isdir(snap_dir):
+            for n in os.listdir(snap_dir):
+                if n.lower().endswith('.jpg'):
+                    z.write(os.path.join(snap_dir, n), arcname=n)
+    buf.seek(0)
+    dl = os.path.splitext(fname)[0] + '.zip'
+    return send_file(buf, as_attachment=True, download_name=dl, mimetype='application/zip')
 
 @app.route("/<album_name>/download/<path:filename>")
 def download_file_get(album_name, filename):
@@ -385,6 +410,32 @@ def album(album_name):
             if not f or f.filename=='':
                 continue
             fname=sanitize_filename(f.filename)
+            ext = os.path.splitext(fname)[1].lower()
+            if ext == '.zip':
+                try:
+                    data = f.read()
+                    with zipfile.ZipFile(io.BytesIO(data)) as z:
+                        vids = [n for n in z.namelist() if os.path.splitext(n)[1].lower() in VIDEO_EXTS]
+                        if len(vids) != 1:
+                            flash(f'压缩包缺少视频: {fname}')
+                            continue
+                        vname = sanitize_filename(os.path.basename(vids[0]))
+                        vdest = os.path.join(path, vname)
+                        with z.open(vids[0]) as vf, open(vdest, 'wb') as out:
+                            shutil.copyfileobj(vf, out)
+                        make_thumb(vdest, thumb_path(album, vname))
+                        sdir = snapshot_dir(album, vname)
+                        for n in z.namelist():
+                            if n == vids[0] or n.endswith('/'):
+                                continue
+                            if os.path.splitext(n)[1].lower() == '.jpg':
+                                bn = sanitize_filename(os.path.basename(n))
+                                with z.open(n) as sf, open(os.path.join(sdir, bn), 'wb') as out:
+                                    shutil.copyfileobj(sf, out)
+                    continue
+                except Exception:
+                    flash(f'压缩包解析失败: {fname}')
+                    continue
             if not allowed(fname):
                 flash(f'类型不允许: {fname}')
                 continue

--- a/EasyReview.py
+++ b/EasyReview.py
@@ -583,5 +583,5 @@ def rename_album(album_name):
     return jsonify({'ok': True, 'new': new})
 
 if __name__=='__main__':
-    PORT = 5123
+    PORT = 5191
     app.run('0.0.0.0',PORT,debug=False)

--- a/templates/album.html
+++ b/templates/album.html
@@ -88,7 +88,7 @@
   <div class="actions">
     <a class='btn' href='{{ url_for("download_file_get", album_name=album, filename=f.name) }}'>下载</a>
     {% if ext in ['mp4','webm','ogg','avi','mov','mkv'] %}
-    <a class='btn' href='{{ url_for("export_video", album_name=album, filename=f.name) }}'>导出</a>
+    <button class='btn' onclick="exportFile('{{ f.name }}')">导出</button>
     {% endif %}
     <button class='btn' onclick="delFile('{{ f.name }}')">删除</button>
   </div>
@@ -116,7 +116,7 @@ drop.addEventListener('drop',e=>{e.preventDefault();drop.style.background='var(-
 input.addEventListener('change',()=>{dropped=null;showList(input.files);});
 function showList(fs){filelist.innerHTML='';for(const f of fs){const li=document.createElement('li');li.textContent=f.name;filelist.appendChild(li);}}
 function fmt(b){const u=['B','KB','MB','GB','TB'];let i=0;while(b>=1024&&i<u.length-1){b/=1024;++i;}return b.toFixed(i?1:0)+' '+u[i];}
-async function upload(){const fs=[...(dropped||input.files)];if(!fs.length)return alert('请选择文件');if(!confirm(`确定上传 ${fs.length} 个文件吗?`))return;document.getElementById('btnup').disabled=true;pw.style.display='block';let done=0,bytes=0,total=fs.reduce((a,b)=>a+b.size,0);
+async function upload(){const fs=[...(dropped||input.files)];if(!fs.length)return alert('请选择文件');if(!confirm(`确定上传 ${fs.length} 个文件吗?`))return;document.getElementById('btnup').disabled=true;pw.style.display='block';pb.style.width='0';pt.textContent='准备上传...';let done=0,bytes=0,total=fs.reduce((a,b)=>a+b.size,0);
   const limit=4;
   const queue=fs.slice();
   const work=async()=>{
@@ -124,7 +124,9 @@ async function upload(){const fs=[...(dropped||input.files)];if(!fs.length)retur
   const doOne=f=>new Promise(r=>{const fd=new FormData();fd.append('file',f);const x=new XMLHttpRequest();x.open('POST',location.pathname);x.upload.onprogress=e=>{pb.style.width=((bytes+e.loaded)/total*100).toFixed(1)+'%';pt.textContent=`${done}/${fs.length}  ${fmt(bytes+e.loaded)} / ${fmt(total)}`;};x.onload=()=>{bytes+=f.size;done++;r();};x.onerror=()=>{alert('失败 '+f.name);r();};x.send(fd);});
   const workers=Array(limit).fill(0).map(work);
   await Promise.all(workers);
-  location.reload();}
+  pt.textContent='上传完成';
+  setTimeout(()=>location.reload(),500);}
+function exportFile(name){const x=new XMLHttpRequest();x.open('GET',`${location.pathname}/export/${encodeURIComponent(name)}`);x.responseType='blob';pw.style.display='block';pb.style.width='0';pt.textContent='准备导出...';x.onprogress=e=>{if(e.lengthComputable){pb.style.width=(e.loaded/e.total*100).toFixed(1)+'%';pt.textContent='导出 '+(e.loaded/e.total*100).toFixed(0)+'%';}else{pt.textContent='导出中...';}};x.onload=()=>{if(x.status===200){const a=document.createElement('a');a.href=URL.createObjectURL(x.response);a.download=name.replace(/\.[^.]+$/,'')+'.zip';document.body.appendChild(a);a.click();a.remove();URL.revokeObjectURL(a.href);pt.textContent='导出完成';setTimeout(()=>{pw.style.display='none';},1000);}else{alert('导出失败');pw.style.display='none';}};x.onerror=()=>{alert('导出失败');pw.style.display='none';};x.send();}
 function delFile(name){if(!confirm('删除 '+name+' ?'))return;fetch(location.pathname+'/delete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file:name})}).then(()=>location.reload());}
 function delAll(){if(!confirm('确定清空相册?'))return;fetch(location.pathname+'/delete_all',{method:'POST'}).then(()=>location.reload());}
 function pack(){const es=new EventSource(location.pathname+'/pack');pw.style.display='block';pb.style.width='0';pt.textContent='';es.onmessage=e=>{if(e.data==='done'){es.close();location.href=location.pathname+'/download_all';}else{pb.style.width=(parseFloat(e.data)*100).toFixed(1)+'%';pt.textContent='打包 '+(parseFloat(e.data)*100).toFixed(0)+'%';}};}

--- a/templates/album.html
+++ b/templates/album.html
@@ -87,6 +87,9 @@
   </figcaption>
   <div class="actions">
     <a class='btn' href='{{ url_for("download_file_get", album_name=album, filename=f.name) }}'>下载</a>
+    {% if ext in ['mp4','webm','ogg','avi','mov','mkv'] %}
+    <a class='btn' href='{{ url_for("export_video", album_name=album, filename=f.name) }}'>导出</a>
+    {% endif %}
     <button class='btn' onclick="delFile('{{ f.name }}')">删除</button>
   </div>
 </figure>{% endfor %}

--- a/templates/album.html
+++ b/templates/album.html
@@ -117,15 +117,31 @@ input.addEventListener('change',()=>{dropped=null;showList(input.files);});
 function showList(fs){filelist.innerHTML='';for(const f of fs){const li=document.createElement('li');li.textContent=f.name;filelist.appendChild(li);}}
 function fmt(b){const u=['B','KB','MB','GB','TB'];let i=0;while(b>=1024&&i<u.length-1){b/=1024;++i;}return b.toFixed(i?1:0)+' '+u[i];}
 async function upload(){const fs=[...(dropped||input.files)];if(!fs.length)return alert('请选择文件');if(!confirm(`确定上传 ${fs.length} 个文件吗?`))return;document.getElementById('btnup').disabled=true;pw.style.display='block';pb.style.width='0';pt.textContent='准备上传...';let done=0,bytes=0,total=fs.reduce((a,b)=>a+b.size,0);
+  const existing=new Set([...document.querySelectorAll('.grid .name')].map(e=>e.textContent.trim()));
   const limit=4;
   const queue=fs.slice();
-  const work=async()=>{
-    while(queue.length){const f=queue.shift();await doOne(f);} };
-  const doOne=f=>new Promise(r=>{const fd=new FormData();fd.append('file',f);const x=new XMLHttpRequest();x.open('POST',location.pathname);x.upload.onprogress=e=>{pb.style.width=((bytes+e.loaded)/total*100).toFixed(1)+'%';pt.textContent=`${done}/${fs.length}  ${fmt(bytes+e.loaded)} / ${fmt(total)}`;};x.onload=()=>{bytes+=f.size;done++;r();};x.onerror=()=>{alert('失败 '+f.name);r();};x.send(fd);});
+  const work=async()=>{while(queue.length){const f=queue.shift();await doOne(f);} };
+  const sanitize=n=>n.replace(/[\u0000-\u001F\u007F]/g,'').replace(/[\\\/]/g,'');
+  const doOne=f=>new Promise(r=>{
+    let name=sanitize(f.name);let overwrite=false;
+    if(existing.has(name)){if(!confirm(name+' 已存在，是否替换?')){bytes+=f.size;done++;r();return;}overwrite=true;}
+    const send=()=>{
+      const fd=new FormData();fd.append('file',f);
+      const x=new XMLHttpRequest();
+      x.open('POST',location.pathname+(overwrite?'?overwrite=1':''));
+      x.upload.onprogress=e=>{pb.style.width=((bytes+e.loaded)/total*100).toFixed(1)+'%';pt.textContent=`${done}/${fs.length}  ${fmt(bytes+e.loaded)} / ${fmt(total)}`;};
+      x.onload=()=>{
+        if(x.status===409&&!overwrite){if(confirm(name+' 已存在，是否替换?')){overwrite=true;send();}else{bytes+=f.size;done++;r();}}
+        else{bytes+=f.size;done++;existing.add(name);r();}};
+      x.onerror=()=>{alert('失败 '+name);bytes+=f.size;done++;r();};
+      x.send(fd);
+    };
+    send();
+  });
   const workers=Array(limit).fill(0).map(work);
   await Promise.all(workers);
   pt.textContent='上传完成';
-  setTimeout(()=>location.reload(),500);}
+  setTimeout(()=>location.reload(),500);} 
 function exportFile(name){const x=new XMLHttpRequest();x.open('GET',`${location.pathname}/export/${encodeURIComponent(name)}`);x.responseType='blob';pw.style.display='block';pb.style.width='0';pt.textContent='准备导出...';x.onprogress=e=>{if(e.lengthComputable){pb.style.width=(e.loaded/e.total*100).toFixed(1)+'%';pt.textContent='导出 '+(e.loaded/e.total*100).toFixed(0)+'%';}else{pt.textContent='导出中...';}};x.onload=()=>{if(x.status===200){const a=document.createElement('a');a.href=URL.createObjectURL(x.response);a.download=name.replace(/\.[^.]+$/,'')+'.zip';document.body.appendChild(a);a.click();a.remove();URL.revokeObjectURL(a.href);pt.textContent='导出完成';setTimeout(()=>{pw.style.display='none';},1000);}else{alert('导出失败');pw.style.display='none';}};x.onerror=()=>{alert('导出失败');pw.style.display='none';};x.send();}
 function delFile(name){if(!confirm('删除 '+name+' ?'))return;fetch(location.pathname+'/delete',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({file:name})}).then(()=>location.reload());}
 function delAll(){if(!confirm('确定清空相册?'))return;fetch(location.pathname+'/delete_all',{method:'POST'}).then(()=>location.reload());}

--- a/templates/review.html
+++ b/templates/review.html
@@ -149,17 +149,19 @@ function sortShots(){
   [...shots.children].sort((a,b)=>parseFloat(a.querySelector('.time').dataset.t)-parseFloat(b.querySelector('.time').dataset.t)).forEach(n=>shots.appendChild(n));
   refreshItems();
 }
-async function renameShot(oldName,newName){
-  const r=await fetch(`${snapUrl}/${encodeURIComponent(oldName)}/rename`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:newName})});
+async function renameShot(oldName,prefix){
+  const r=await fetch(`${snapUrl}/${encodeURIComponent(oldName)}/rename`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prefix})});
   const d=await r.json();
   if(d.ok)return d.name;
   alert('改名失败');
   return null;
 }
-function startEdit(span,cb){
+function startEditShot(span,fullName,cb){
   if(span.dataset.editing)return;
   span.dataset.editing='1';
-  const old=span.textContent;
+  const base=fullName.replace(/\.jpg$/i,'');
+  const idx=base.lastIndexOf('_');
+  const old=idx>=0?base.slice(0,idx):'';
   const input=document.createElement('input');
   input.type='text';
   input.value=old;
@@ -171,10 +173,10 @@ function startEdit(span,cb){
     input.replaceWith(span);
     span.dataset.editing='';
     const val=input.value.trim();
-    if(doRename&&val&&val!==old){
-      await cb(old,val);
+    if(doRename&&val!==old){
+      await cb(val);
     }else{
-      span.textContent=old;
+      span.textContent=fullName;
     }
   };
   input.addEventListener('blur',()=>finish(true));
@@ -195,7 +197,7 @@ function addShot(name,time){
   const nameSpan=document.createElement('span');nameSpan.className='name';nameSpan.textContent=currentName;
   nameSpan.addEventListener('click',e=>{
     e.stopPropagation();
-    startEdit(nameSpan,async(old,val)=>{
+    startEditShot(nameSpan,currentName,async(val)=>{
       const nn=await renameShot(currentName,val);
       if(nn){currentName=nn;nameSpan.textContent=nn;img.src=`${snapUrl}/${currentName}`;img.dataset.full=img.src;}
     });

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -53,12 +53,22 @@ def test_delete_and_clear(client, album_path):
 
 
 def test_pack_zip(client, album_path):
-    data = {"file": (io.BytesIO(b"xyz"), "c.jpg")}
+    data = {"file": (io.BytesIO(b"vid"), "v.mp4")}
     client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    sdir = os.path.join(album_path, ".review", "v.mp4")
+    os.makedirs(sdir, exist_ok=True)
+    with open(os.path.join(sdir, "1.jpg"), "wb") as f:
+        f.write(b"i")
     resp = client.get(f"/{ALBUM}/pack")
+    _ = resp.data
     zpath = os.path.join(album_path, f"{ALBUM}.zip")
     assert resp.status_code == 200
     assert os.path.isfile(zpath)
+    with zipfile.ZipFile(zpath) as outer:
+        assert "v.zip" in outer.namelist()
+        with zipfile.ZipFile(io.BytesIO(outer.read("v.zip"))) as inner:
+            assert "v.mp4" in inner.namelist()
+            assert "1.jpg" in inner.namelist()
 
 
 def test_rename_album(client, album_path):
@@ -87,6 +97,19 @@ def test_rename_file(client, album_path):
     assert resp.status_code == 200
     assert os.path.isfile(os.path.join(album_path, "new.jpg"))
     assert os.path.isdir(os.path.join(album_path, ".review", "new.jpg"))
+
+
+def test_upload_conflict(client, album_path):
+    data = {"file": (io.BytesIO(b"a"), "dup.jpg")}
+    client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    data_conflict = {"file": (io.BytesIO(b"a"), "dup.jpg")}
+    resp = client.post(f"/{ALBUM}", data=data_conflict, content_type="multipart/form-data")
+    assert resp.status_code == 409
+    data2 = {"file": (io.BytesIO(b"b"), "dup.jpg")}
+    resp = client.post(f"/{ALBUM}?overwrite=1", data=data2, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    with open(os.path.join(album_path, "dup.jpg"), "rb") as f:
+        assert f.read() == b"b"
 
 
 def test_snapshot_rename_and_export(client, album_path):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
-import os
 import io
+import os
 import shutil
+import zipfile
 import pytest
 import sys
 
@@ -86,4 +87,36 @@ def test_rename_file(client, album_path):
     assert resp.status_code == 200
     assert os.path.isfile(os.path.join(album_path, "new.jpg"))
     assert os.path.isdir(os.path.join(album_path, ".review", "new.jpg"))
+
+
+def test_snapshot_rename_and_export(client, album_path):
+    # upload a video
+    data = {"file": (io.BytesIO(b"v"), "vid.mp4")}
+    client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    snap_dir = os.path.join(album_path, ".review", "vid.mp4")
+    os.makedirs(snap_dir, exist_ok=True)
+    snap_path = os.path.join(snap_dir, "1.000.jpg")
+    with open(snap_path, "wb") as f:
+        f.write(b"img")
+    # rename snapshot with prefix
+    resp = client.post(f"/{ALBUM}/review/vid.mp4/snapshots/1.000.jpg/rename", json={"prefix": "aaa"})
+    assert resp.status_code == 200
+    assert os.path.isfile(os.path.join(snap_dir, "aaa_1.000.jpg"))
+    # export
+    resp = client.get(f"/{ALBUM}/export/vid.mp4")
+    z = zipfile.ZipFile(io.BytesIO(resp.data))
+    assert "vid.mp4" in z.namelist()
+    assert "aaa_1.000.jpg" in z.namelist()
+
+
+def test_zip_upload_restore(client, album_path):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as z:
+        z.writestr('vid.mp4', b'v')
+        z.writestr('aaa_1.000.jpg', b'i')
+    buf.seek(0)
+    data = {"file": (buf, "pack.zip")}
+    client.post(f"/{ALBUM}", data=data, content_type="multipart/form-data")
+    assert os.path.isfile(os.path.join(album_path, "vid.mp4"))
+    assert os.path.isfile(os.path.join(album_path, ".review", "vid.mp4", "aaa_1.000.jpg"))
 


### PR DESCRIPTION
## Summary
- Allow renaming only the prefix of video snapshots while keeping timestamps and sorting by trailing timestamp
- Add export endpoint and UI button to download a video with its snapshots as a zip
- Accept zip uploads and restore packaged videos with snapshots into albums

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad1d4899c483209783032b4eb2f8fa