### PR TITLE
Add automatic scene detection on review page

### DIFF
--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -1,1 +1,0 @@
-from EasyReview import *  # re-export everything for compatibility

--- a/EasyAlbumWeb.py
+++ b/EasyAlbumWeb.py
@@ -1,0 +1,1 @@
+from EasyReview import *  # re-export everything for compatibility

--- a/EasyReview.py
+++ b/EasyReview.py
@@ -334,6 +334,54 @@ def review_snapshot_delete_all(album_name, filename):
     return jsonify({'ok': True})
 
 
+@app.route("/<album_name>/review/<path:filename>/snapshots/auto", methods=['POST'])
+def review_snapshot_auto(album_name, filename):
+    """Automatically split video into scenes and save mid-frame snapshots."""
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    src = os.path.join(UPLOAD_ROOT, album, fname)
+    if not os.path.isfile(src):
+        abort(404)
+    out_dir = snapshot_dir(album, fname)
+
+    try:
+        from scenedetect import VideoManager, SceneManager
+        from scenedetect.detectors import ContentDetector
+        import cv2
+    except Exception:
+        return jsonify({'ok': False, 'msg': 'missing dependency'}), 500
+
+    video_manager = VideoManager([src])
+    scene_manager = SceneManager()
+    scene_manager.add_detector(ContentDetector(threshold=26.0))
+    video_manager.start()
+    scene_manager.detect_scenes(frame_source=video_manager)
+    scene_list = scene_manager.get_scene_list()
+    video_manager.release()
+
+    cap = cv2.VideoCapture(src)
+    if not cap.isOpened():
+        return jsonify({'ok': False, 'msg': 'open failed'}), 500
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    saved = 0
+    for i, (start_tc, end_tc) in enumerate(scene_list, start=1):
+        start_f = start_tc.get_frames()
+        end_f = end_tc.get_frames()
+        if end_f <= start_f:
+            continue
+        mid_f = (start_f + end_f) // 2
+        cap.set(cv2.CAP_PROP_POS_FRAMES, mid_f)
+        ok, frame = cap.read()
+        if not ok or frame is None:
+            continue
+        mid_sec = mid_f / fps if fps > 0 else 0.0
+        name = f"场景{i}_{mid_sec:.3f}.jpg"
+        cv2.imwrite(os.path.join(out_dir, name), frame, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+        saved += 1
+    cap.release()
+    return jsonify({'ok': True, 'saved': saved})
+
+
 @app.route("/<album_name>/export/<path:filename>")
 def export_video(album_name, filename):
     album = safe_album(album_name)

--- a/EasyReview.py
+++ b/EasyReview.py
@@ -365,6 +365,12 @@ def review_snapshot_auto(album_name, filename):
     fps = cap.get(cv2.CAP_PROP_FPS)
     saved = 0
 
+    def save_frame(path, frame):
+        """Write JPEG using a method that supports non-ASCII paths."""
+        ret, buf = cv2.imencode('.jpg', frame, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+        if ret:
+            buf.tofile(path)
+
     # Fallback: if no scenes are detected, capture the middle frame of the whole video.
     if not scene_list:
         frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
@@ -375,7 +381,7 @@ def review_snapshot_auto(album_name, filename):
             if ok and frame is not None:
                 mid_sec = mid_f / fps if fps > 0 else 0.0
                 name = f"场景1_{mid_sec:.3f}.jpg"
-                cv2.imwrite(os.path.join(out_dir, name), frame, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+                save_frame(os.path.join(out_dir, name), frame)
                 saved = 1
         cap.release()
         return jsonify({'ok': True, 'saved': saved})
@@ -392,7 +398,7 @@ def review_snapshot_auto(album_name, filename):
             continue
         mid_sec = mid_f / fps if fps > 0 else 0.0
         name = f"场景{i}_{mid_sec:.3f}.jpg"
-        cv2.imwrite(os.path.join(out_dir, name), frame, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+        save_frame(os.path.join(out_dir, name), frame)
         saved += 1
     cap.release()
     return jsonify({'ok': True, 'saved': saved})

--- a/EasyReview.py
+++ b/EasyReview.py
@@ -36,6 +36,8 @@ os.makedirs(UPLOAD_ROOT, exist_ok=True)
 THUMB_DIR = ".thumbs"
 THUMB_SIZE = (320, 320)
 executor = ThreadPoolExecutor(max_workers=4)
+AUTO_PROGRESS = {}
+AUTO_RESULT = {}
 PLACEHOLDER = (
     b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\x00"
     b"\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
@@ -334,22 +336,19 @@ def review_snapshot_delete_all(album_name, filename):
     return jsonify({'ok': True})
 
 
-@app.route("/<album_name>/review/<path:filename>/snapshots/auto", methods=['POST'])
-def review_snapshot_auto(album_name, filename):
-    """Automatically split video into scenes and save mid-frame snapshots."""
-    album = safe_album(album_name)
-    fname = sanitize_filename(filename)
+def _auto_split_worker(album: str, fname: str):
+    """Background worker performing scene detection and snapshot saving."""
+    key = f"{album}/{fname}"
     src = os.path.join(UPLOAD_ROOT, album, fname)
-    if not os.path.isfile(src):
-        abort(404)
     out_dir = snapshot_dir(album, fname)
-
     try:
         from scenedetect import VideoManager, SceneManager
         from scenedetect.detectors import ContentDetector
         import cv2
     except Exception:
-        return jsonify({'ok': False, 'msg': 'missing dependency'}), 500
+        AUTO_RESULT[key] = {'ok': False, 'msg': 'missing dependency', 'saved': 0}
+        AUTO_PROGRESS.pop(key, None)
+        return
 
     video_manager = VideoManager([src])
     scene_manager = SceneManager()
@@ -361,17 +360,20 @@ def review_snapshot_auto(album_name, filename):
 
     cap = cv2.VideoCapture(src)
     if not cap.isOpened():
-        return jsonify({'ok': False, 'msg': 'open failed'}), 500
+        AUTO_RESULT[key] = {'ok': False, 'msg': 'open failed', 'saved': 0}
+        AUTO_PROGRESS.pop(key, None)
+        return
     fps = cap.get(cv2.CAP_PROP_FPS)
     saved = 0
 
     def save_frame(path, frame):
-        """Write JPEG using a method that supports non-ASCII paths."""
         ret, buf = cv2.imencode('.jpg', frame, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
         if ret:
             buf.tofile(path)
 
-    # Fallback: if no scenes are detected, capture the middle frame of the whole video.
+    # After detection done, mark half progress
+    AUTO_PROGRESS[key] = 0.5
+
     if not scene_list:
         frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
         if frame_count > 0:
@@ -379,13 +381,16 @@ def review_snapshot_auto(album_name, filename):
             cap.set(cv2.CAP_PROP_POS_FRAMES, mid_f)
             ok, frame = cap.read()
             if ok and frame is not None:
-                mid_sec = mid_f / fps if fps > 0 else 0.0
-                name = f"场景1_{mid_sec:.3f}.jpg"
+                actual = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0 if fps > 0 else 0.0
+                name = f"场景1_{actual:.3f}.jpg"
                 save_frame(os.path.join(out_dir, name), frame)
                 saved = 1
         cap.release()
-        return jsonify({'ok': True, 'saved': saved})
+        AUTO_RESULT[key] = {'ok': True, 'saved': saved}
+        AUTO_PROGRESS.pop(key, None)
+        return
 
+    total = len(scene_list)
     for i, (start_tc, end_tc) in enumerate(scene_list, start=1):
         start_f = start_tc.get_frames()
         end_f = end_tc.get_frames()
@@ -396,12 +401,42 @@ def review_snapshot_auto(album_name, filename):
         ok, frame = cap.read()
         if not ok or frame is None:
             continue
-        mid_sec = mid_f / fps if fps > 0 else 0.0
-        name = f"场景{i}_{mid_sec:.3f}.jpg"
+        actual = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0 if fps > 0 else 0.0
+        name = f"场景{i}_{actual:.3f}.jpg"
         save_frame(os.path.join(out_dir, name), frame)
         saved += 1
+        AUTO_PROGRESS[key] = 0.5 + 0.5 * (i / total)
     cap.release()
-    return jsonify({'ok': True, 'saved': saved})
+    AUTO_RESULT[key] = {'ok': True, 'saved': saved}
+    AUTO_PROGRESS.pop(key, None)
+
+
+@app.route("/<album_name>/review/<path:filename>/snapshots/auto", methods=['POST'])
+def review_snapshot_auto(album_name, filename):
+    """Kick off background auto scene detection."""
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    src = os.path.join(UPLOAD_ROOT, album, fname)
+    if not os.path.isfile(src):
+        abort(404)
+    key = f"{album}/{fname}"
+    if key in AUTO_PROGRESS:
+        return jsonify({'ok': False, 'msg': 'busy'}), 409
+    AUTO_PROGRESS[key] = 0.0
+    AUTO_RESULT.pop(key, None)
+    executor.submit(_auto_split_worker, album, fname)
+    return jsonify({'ok': True})
+
+
+@app.route("/<album_name>/review/<path:filename>/snapshots/auto/progress")
+def review_snapshot_auto_progress(album_name, filename):
+    album = safe_album(album_name)
+    fname = sanitize_filename(filename)
+    key = f"{album}/{fname}"
+    p = AUTO_PROGRESS.get(key)
+    res = AUTO_RESULT.get(key, {})
+    done = p is None
+    return jsonify({'ok': True, 'progress': p if p is not None else 1.0, 'done': done, **res})
 
 
 @app.route("/<album_name>/export/<path:filename>")

--- a/EasyReview.py
+++ b/EasyReview.py
@@ -364,6 +364,22 @@ def review_snapshot_auto(album_name, filename):
         return jsonify({'ok': False, 'msg': 'open failed'}), 500
     fps = cap.get(cv2.CAP_PROP_FPS)
     saved = 0
+
+    # Fallback: if no scenes are detected, capture the middle frame of the whole video.
+    if not scene_list:
+        frame_count = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+        if frame_count > 0:
+            mid_f = int(frame_count // 2)
+            cap.set(cv2.CAP_PROP_POS_FRAMES, mid_f)
+            ok, frame = cap.read()
+            if ok and frame is not None:
+                mid_sec = mid_f / fps if fps > 0 else 0.0
+                name = f"场景1_{mid_sec:.3f}.jpg"
+                cv2.imwrite(os.path.join(out_dir, name), frame, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+                saved = 1
+        cap.release()
+        return jsonify({'ok': True, 'saved': saved})
+
     for i, (start_tc, end_tc) in enumerate(scene_list, start=1):
         start_f = start_tc.get_frames()
         end_f = end_tc.get_frames()

--- a/EasyReview.py
+++ b/EasyReview.py
@@ -336,7 +336,7 @@ def review_snapshot_delete_all(album_name, filename):
     return jsonify({'ok': True})
 
 
-def _auto_split_worker(album: str, fname: str):
+def _auto_split_worker(album: str, fname: str, threshold: float):
     """Background worker performing scene detection and snapshot saving."""
     key = f"{album}/{fname}"
     src = os.path.join(UPLOAD_ROOT, album, fname)
@@ -352,7 +352,7 @@ def _auto_split_worker(album: str, fname: str):
 
     video_manager = VideoManager([src])
     scene_manager = SceneManager()
-    scene_manager.add_detector(ContentDetector(threshold=26.0))
+    scene_manager.add_detector(ContentDetector(threshold=threshold))
     video_manager.start()
     scene_manager.detect_scenes(frame_source=video_manager)
     scene_list = scene_manager.get_scene_list()
@@ -422,9 +422,16 @@ def review_snapshot_auto(album_name, filename):
     key = f"{album}/{fname}"
     if key in AUTO_PROGRESS:
         return jsonify({'ok': False, 'msg': 'busy'}), 409
+
+    data = request.get_json(silent=True) or {}
+    try:
+        threshold = float(data.get('threshold', 27))
+    except Exception:
+        threshold = 27.0
+
     AUTO_PROGRESS[key] = 0.0
     AUTO_RESULT.pop(key, None)
-    executor.submit(_auto_split_worker, album, fname)
+    executor.submit(_auto_split_worker, album, fname, threshold)
     return jsonify({'ok': True})
 
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,17 @@
 pip install Flask Pillow
 ```
 
-### 可选  
+### 可选
 | 功能 | 包 | 安装命令 |
 |------|----|-----------|
 | RAW 预览 | rawpy imageio | `pip install rawpy imageio` |
 | 视频缩略图 | opencv-python | `pip install opencv-python` |
+| 自动分场景 | scenedetect opencv-python | `pip install scenedetect opencv-python` |
 | 生产部署 | gunicorn | `pip install gunicorn` |
 
 ## 快速运行
 ```bash
-python EasyAlbumWeb.py
+python EasyReview.py
 # 浏览器访问 http://<本机或局域网IP>:5123
 ```
 
@@ -34,7 +35,7 @@ python -m pytest -v
 - **uploads/** 上传文件根目录，子文件夹即相册名  
 - **.thumbs/** 每个相册下自动生成的缩略图缓存  
 
-> 默认单文件大小上限 5 GB，可在 `EasyAlbumWeb.py` 顶部 `MAX_CONTENT_LENGTH` 修改。
+> 默认单文件大小上限 5 GB，可在 `EasyReview.py` 顶部 `MAX_CONTENT_LENGTH` 修改。
 
 ## License
 MIT

--- a/templates/review.html
+++ b/templates/review.html
@@ -114,7 +114,12 @@ autoBtn.addEventListener('click',async()=>{
   progress.style.display='block';
   try{
     const r=await fetch(snapUrl+'/auto',{method:'POST'});
-    if(!r.ok) alert('分场景失败');
+    if(r.ok){
+      const info=await r.json();
+      if(!info.ok || !info.saved) alert('未检测到场景');
+    }else{
+      alert('分场景失败');
+    }
   }catch(e){alert('分场景失败');}
   await loadShots();
   progress.style.display='none';

--- a/templates/review.html
+++ b/templates/review.html
@@ -105,25 +105,47 @@ document.getElementById('shotBtn').addEventListener('click',capture);
 document.getElementById('delAll').onclick=async()=>{
   if(!confirm('全部删除?'))return;
   await fetch(snapUrl+'/delete_all',{method:'POST'});
-  shots.innerHTML='';
-  refreshItems();
+  await loadShots();
 };
 autoBtn.addEventListener('click',async()=>{
   if(autoBtn.disabled) return;
   autoBtn.disabled=true;
+  progress.value=0;progress.max=1;progress.textContent='0%';
   progress.style.display='block';
   try{
     const r=await fetch(snapUrl+'/auto',{method:'POST'});
     const info=await r.json().catch(()=>({}));
-    if(r.ok){
-      if(!info.ok || !info.saved) alert('未检测到场景');
-    }else{
-      alert(info.msg||'分场景失败');
+    if(!r.ok||!info.ok) throw new Error(info.msg||'分场景失败');
+  }catch(e){
+    alert(e.message||'分场景失败');
+    progress.style.display='none';
+    autoBtn.disabled=false;
+    return;
+  }
+  const timer=setInterval(async()=>{
+    try{
+      const r=await fetch(snapUrl+'/auto/progress',{cache:'no-store'});
+      const info=await r.json();
+      if(!r.ok){throw new Error();}
+      progress.value=info.progress;
+      progress.textContent=Math.round(info.progress*100)+'%';
+      if(info.done){
+        clearInterval(timer);
+        progress.style.display='none';
+        progress.textContent='';
+        autoBtn.disabled=false;
+        if(!info.ok) alert(info.msg||'分场景失败');
+        else if(!info.saved) alert('未检测到场景');
+        await loadShots();
+      }
+    }catch(e){
+      clearInterval(timer);
+      progress.style.display='none';
+      progress.textContent='';
+      autoBtn.disabled=false;
+      alert('分场景失败');
     }
-  }catch(e){alert('分场景失败');}
-  await loadShots();
-  progress.style.display='none';
-  autoBtn.disabled=false;
+  },500);
 });
 let idx=-1,scale=1,offX=0,offY=0,splitDrag=false;
 function seek(d){video.currentTime=Math.max(0,video.currentTime+d);}

--- a/templates/review.html
+++ b/templates/review.html
@@ -114,11 +114,11 @@ autoBtn.addEventListener('click',async()=>{
   progress.style.display='block';
   try{
     const r=await fetch(snapUrl+'/auto',{method:'POST'});
+    const info=await r.json().catch(()=>({}));
     if(r.ok){
-      const info=await r.json();
       if(!info.ok || !info.saved) alert('未检测到场景');
     }else{
-      alert('分场景失败');
+      alert(info.msg||'分场景失败');
     }
   }catch(e){alert('分场景失败');}
   await loadShots();
@@ -163,11 +163,12 @@ async function capture(){
   if(info.ok)addShot(info.name,t);
 }
 async function loadShots(){
-  const res=await fetch(snapUrl);
+  const res=await fetch(snapUrl,{cache:'no-store'});
   const arr=await res.json();
   shots.innerHTML='';
   arr.forEach(s=>addShot(s.name,s.time));
   if(autoBtn){autoBtn.style.display=arr.length?'none':'';}
+  refreshItems();
 }
 function refreshItems(){items.splice(0,items.length,...document.querySelectorAll('#list img'));}
 function sortShots(){

--- a/templates/review.html
+++ b/templates/review.html
@@ -109,11 +109,15 @@ document.getElementById('delAll').onclick=async()=>{
 };
 autoBtn.addEventListener('click',async()=>{
   if(autoBtn.disabled) return;
+  const val=prompt('请输入分场景阈值(默认27，越大越保守)','27');
+  if(val===null) return;
+  const t=parseFloat(val);
+  const threshold=isNaN(t)?27:t;
   autoBtn.disabled=true;
   progress.value=0;progress.max=1;progress.textContent='0%';
   progress.style.display='block';
   try{
-    const r=await fetch(snapUrl+'/auto',{method:'POST'});
+    const r=await fetch(snapUrl+'/auto',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({threshold})});
     const info=await r.json().catch(()=>({}));
     if(!r.ok||!info.ok) throw new Error(info.msg||'分场景失败');
   }catch(e){

--- a/templates/review.html
+++ b/templates/review.html
@@ -73,7 +73,11 @@
   </div>
   <div id='divider'></div>
   <div id='shots'>
-    <div id='toolbar'><button id='delAll' class='btn'>全部删除</button></div>
+    <div id='toolbar'>
+      <button id='delAll' class='btn'>全部删除</button>
+      <button id='autoScene' class='btn' style='display:none'>自动分场景</button>
+    </div>
+    <progress id='sceneProgress' style='display:none;width:100%'></progress>
     <div id='help'>快捷键: F/D/S/A 后退0.5/1/3/5秒，J/K/L/; 前进0.5/1/3/5秒，空格 播放/暂停，回车 保存截图</div>
     <div id='list'></div>
   </div>
@@ -87,6 +91,8 @@ const video=document.getElementById('video');
 const divider=document.getElementById('divider');
 const snapUrl='/' + encodeURIComponent('{{ album }}') + '/review/' + encodeURIComponent('{{ filename }}') + '/snapshots';
 const shots=document.getElementById('list');
+const autoBtn=document.getElementById('autoScene');
+const progress=document.getElementById('sceneProgress');
 const items=[];
 document.querySelectorAll('#controls [data-seek]').forEach(btn=>btn.addEventListener('click',()=>seek(parseFloat(btn.dataset.seek))));
 const pauseBtn=document.getElementById('pauseBtn');
@@ -102,6 +108,18 @@ document.getElementById('delAll').onclick=async()=>{
   shots.innerHTML='';
   refreshItems();
 };
+autoBtn.addEventListener('click',async()=>{
+  if(autoBtn.disabled) return;
+  autoBtn.disabled=true;
+  progress.style.display='block';
+  try{
+    const r=await fetch(snapUrl+'/auto',{method:'POST'});
+    if(!r.ok) alert('分场景失败');
+  }catch(e){alert('分场景失败');}
+  await loadShots();
+  progress.style.display='none';
+  autoBtn.disabled=false;
+});
 let idx=-1,scale=1,offX=0,offY=0,splitDrag=false;
 function seek(d){video.currentTime=Math.max(0,video.currentTime+d);}
 function handleKey(e){
@@ -142,7 +160,9 @@ async function capture(){
 async function loadShots(){
   const res=await fetch(snapUrl);
   const arr=await res.json();
+  shots.innerHTML='';
   arr.forEach(s=>addShot(s.name,s.time));
+  if(autoBtn){autoBtn.style.display=arr.length?'none':'';}
 }
 function refreshItems(){items.splice(0,items.length,...document.querySelectorAll('#list img'));}
 function sortShots(){

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,7 @@ import sys
 # Ensure the project root is on sys.path when running via the pytest binary
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from EasyAlbumWeb import app, UPLOAD_ROOT
+from EasyReview import app, UPLOAD_ROOT
 
 ALBUM = "test"
 


### PR DESCRIPTION
## Summary
- add backend endpoint to split video into scenes and save mid-frame snapshots named with scene number and timestamp
- show an **自动分场景** button on the review page when no snapshots exist, disable during processing, and display a progress bar
- create compatibility alias `EasyAlbumWeb.py` for tests

## Testing
- ✅ `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad479c0300832096585c3f5e0c834b